### PR TITLE
Ensure that contains edges are not emitted if there is no adjacent vertex

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -106,9 +106,11 @@ func (e *exporter) export(info protocol.ToolInfo) error {
 			}
 		}
 
-		_, err = e.emitContains(f.docID, append(f.defRangeIDs, f.useRangeIDs...))
-		if err != nil {
-			return fmt.Errorf(`emit "contains": %v`, err)
+		if len(f.defRangeIDs) > 0 || len(f.useRangeIDs) > 0 {
+			_, err = e.emitContains(f.docID, append(f.defRangeIDs, f.useRangeIDs...))
+			if err != nil {
+				return fmt.Errorf(`emit "contains": %v`, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
Do not emit edges that do not have multiple adjacent vertices. This is, as far as I can tell, can only happen for a definition with no references when emitting a contains edge.

Previously, lsif-util would not validate the output of gorilla/mux. After this change it validates. This also closes #4.

Here is the parallel line from lsif-py: https://github.com/sourcegraph/lsif-py/blob/5669e34d288df03b7bf5677f891a400c0c4ce036/lsif_indexer/index.py#L220