### PR TITLE
Remove useless duplicated hover result

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -397,16 +397,6 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 			return fmt.Errorf(`emit "item": %v`, err)
 		}
 
-		hoverResultID, err := e.emitHoverResult(def.contents)
-		if err != nil {
-			return fmt.Errorf(`emit "hoverResult": %v`, err)
-		}
-
-		_, err = e.emitTextDocumentHover(def.resultSetID, hoverResultID)
-		if err != nil {
-			return fmt.Errorf(`emit "textDocument/hover": %v`, err)
-		}
-
 		rangeIDs = append(rangeIDs, rangeID)
 
 		refResult := e.refs[def.rangeID]


### PR DESCRIPTION
These two lines created a hover result and linked it to the definition's result set id. These edges already exist from exportDef (maybe it was originally written to link the use result id to the hover result id, but that's not the behavior).

This reduces file size slightly (1.5M -> 1.1M for gorilla/mux) but also reduces edges that go nowhere and edges that we'll have to query via json/sqlite/dgraph at runtime.

This closes #5.