### PR TITLE
Emit events

### DIFF
--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -135,7 +135,7 @@ func NewEvent(id, kind, scope string, data string) *Event {
 		},
 		Kind:  kind,
 		Scope: scope,
-		Data:  data, // TODO - will need to be int soon
+		Data:  data,
 	}
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -124,7 +124,7 @@ type Event struct {
 
 // NewEvent returns a new Event object with the given ID, kind, scope,
 // and data information.
-func NewEvent(id, kind, scope string, data string) *Event {
+func NewEvent(id, kind, scope, data string) *Event {
 	return &Event{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -119,12 +119,12 @@ type Event struct {
 	// The type of element this event describes (project or document).
 	Scope string `json:"scope"`
 	// The identifier of the data beginning or ending.
-	Data int `json:"data"`
+	Data string `json:"data"`
 }
 
 // NewEvent returns a new Event object with the given ID, kind, scope,
 // and data information.
-func NewEvent(id, kind, scope string, data int) *Event {
+func NewEvent(id, kind, scope string, data string) *Event {
 	return &Event{
 		Vertex: Vertex{
 			Element: Element{
@@ -135,7 +135,7 @@ func NewEvent(id, kind, scope string, data int) *Event {
 		},
 		Kind:  kind,
 		Scope: scope,
-		Data:  data,
+		Data:  data, // TODO - will need to be int soon
 	}
 }
 

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -110,6 +110,35 @@ func NewMetaData(id, root string, info ToolInfo) *MetaData {
 	}
 }
 
+// Event is optional metadata emitted to give hints to consumers about
+// the beginning and ending of new "socpes" (e.g. a project or document).
+type Event struct {
+	Vertex
+	// The kind of event (begin or end).
+	Kind string `json:"kind"`
+	// The type of element this event describes (project or document).
+	Scope string `json:"scope"`
+	// The identifier of the data beginning or ending.
+	Data int `json:"data"`
+}
+
+// NewEvent returns a new Event object with the given ID, kind, scope,
+// and data information.
+func NewEvent(id, kind, scope string, data int) *Event {
+	return &Event{
+		Vertex: Vertex{
+			Element: Element{
+				ID:   id,
+				Type: ElementVertex,
+			},
+			Label: VertexEvent,
+		},
+		Kind:  kind,
+		Scope: scope,
+		Data:  data,
+	}
+}
+
 // Project declares the language of the dump.
 type Project struct {
 	Vertex


### PR DESCRIPTION
These events are required for lsif-sqlite to properly be able to convert the dumps into a database.