### PR TITLE
Remove duplicate document end $event vertices.

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -119,6 +119,19 @@ func (e *exporter) export(info protocol.ToolInfo) error {
 		}
 	}
 
+	// Close all documents
+	// TODO(efritz) - see if we can rearrange the outputs so that
+	// all of the output for a document is contained in one segment
+	// that does not interfere with emission of other document
+	// properties.
+
+	for _, info := range e.files {
+		_, err = e.emitEndEvent("document", info.docID)
+		if err != nil {
+			return fmt.Errorf(`emit "end": %v`, err)
+		}
+	}
+
 	_, err = e.emitEndEvent("project", proID)
 	if err != nil {
 		return fmt.Errorf(`emit "end": %v`, err)
@@ -163,13 +176,6 @@ func (e *exporter) exportPkg(p *packages.Package, proID string) (err error) {
 
 		if err := e.exportUses(p, fi, fpos.Filename); err != nil {
 			return fmt.Errorf("error exporting uses of %q: %v", p.PkgPath, err)
-		}
-	}
-
-	for _, info := range e.files {
-		_, err = e.emitEndEvent("document", info.docID)
-		if err != nil {
-			return fmt.Errorf(`emit "end": %v`, err)
 		}
 	}
 

--- a/export/exporter.go
+++ b/export/exporter.go
@@ -119,7 +119,9 @@ func (e *exporter) export(info protocol.ToolInfo) error {
 		}
 	}
 
-	// Close all documents
+	// Close all documents. This must be done as a last step as we need
+	// to emit everything about a document before sending the end event.
+
 	// TODO(efritz) - see if we can rearrange the outputs so that
 	// all of the output for a document is contained in one segment
 	// that does not interfere with emission of other document


### PR DESCRIPTION
This fixes a problem where the size of e.files grows and the number of times a document is output is the number of files processed after it.