### PR TITLE
export/exporter: emit refs after all files are processed in a package (#10)

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -162,9 +162,9 @@ func (e *exporter) exportPkg(p *packages.Package, proID string) (err error) {
 		}
 	}
 
-	// NOTE: since we currently only support package-level references, it is OK to run the loop
-	//       here. Once we want repository (or Go module)-level references, they can only be
-	//       handled after all files are processed for definitions.
+	// NOTE: since we currently only support package-level references, it is OK to export usages
+	// at the end of each package. When repository-level references are implemented, usages must
+	// be exported after all files are processed.
 	for _, f := range p.Syntax {
 		fpos := p.Fset.Position(f.Package)
 		if err := e.exportUses(p, e.files[fpos.Filename], fpos.Filename); err != nil {

--- a/export/exporter.go
+++ b/export/exporter.go
@@ -160,8 +160,14 @@ func (e *exporter) exportPkg(p *packages.Package, proID string) (err error) {
 		if err = e.exportDefs(p, f, fi, proID, fpos.Filename); err != nil {
 			return fmt.Errorf("error exporting definitions of %q: %v", p.PkgPath, err)
 		}
+	}
 
-		if err := e.exportUses(p, fi, fpos.Filename); err != nil {
+	// NOTE: since we currently only support package-level references, it is OK to run the loop
+	//       here. Once we want repository (or Go module)-level references, they can only be
+	//       handled after all files are processed for definitions.
+	for _, f := range p.Syntax {
+		fpos := p.Fset.Position(f.Package)
+		if err := e.exportUses(p, e.files[fpos.Filename], fpos.Filename); err != nil {
 			return fmt.Errorf("error exporting uses of %q: %v", p.PkgPath, err)
 		}
 	}


### PR DESCRIPTION
Emit refs on each file basis will lose connections to defs defined in files that have not yet processed.

Finished k8s/k8s repo in 1m32s with 1.1G (was 816M after #3) w/o compression, w/o embedding file content.

Context: #10