### PR TITLE
Support more object types

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -43,12 +43,13 @@ func Export(workspace string, excludeContent bool, w io.Writer, toolInfo protoco
 		excludeContent: excludeContent,
 		w:              w,
 
-		pkgs:  pkgs,
-		files: make(map[string]*fileInfo),
-		funcs: make(map[string]*defInfo),
-		vars:  make(map[token.Pos]*defInfo),
-		types: make(map[string]*defInfo),
-		refs:  make(map[string]*refResultInfo),
+		pkgs:   pkgs,
+		files:  make(map[string]*fileInfo),
+		funcs:  make(map[string]*defInfo),
+		consts: make(map[token.Pos]*defInfo),
+		vars:   make(map[token.Pos]*defInfo),
+		types:  make(map[string]*defInfo),
+		refs:   make(map[string]*refResultInfo),
 	}).export(toolInfo)
 }
 
@@ -58,13 +59,14 @@ type exporter struct {
 	excludeContent bool
 	w              io.Writer
 
-	id    int // The ID counter of the last element emitted
-	pkgs  []*packages.Package
-	files map[string]*fileInfo      // Keys: filename
-	funcs map[string]*defInfo       // Keys: full name (with receiver for methods)
-	vars  map[token.Pos]*defInfo    // Keys: definition position
-	types map[string]*defInfo       // Keys: type name
-	refs  map[string]*refResultInfo // Keys: definition range ID
+	id     int // The ID counter of the last element emitted
+	pkgs   []*packages.Package
+	files  map[string]*fileInfo      // Keys: filename
+	funcs  map[string]*defInfo       // Keys: full name (with receiver for methods)
+	consts map[token.Pos]*defInfo    // Keys: definition position
+	vars   map[token.Pos]*defInfo    // Keys: definition position
+	types  map[string]*defInfo       // Keys: type name
+	refs   map[string]*refResultInfo // Keys: definition range ID
 }
 
 func (e *exporter) export(info protocol.ToolInfo) error {
@@ -285,7 +287,16 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 				contents:    contents,
 			}
 
-		// TODO(jchen): case *types.Const:
+		case *types.Const:
+			// TODO(jchen): support "-verbose" flag
+			//fmt.Printf("---> %T\n", obj)
+			//fmt.Println("Def:", ident.Name)
+			//fmt.Println("iPos:", ipos)
+			e.consts[ident.Pos()] = &defInfo{
+				rangeID:     rangeID,
+				resultSetID: refResult.resultSetID,
+				contents:    contents,
+			}
 
 		case *types.Var:
 			// TODO(jchen): support "-verbose" flag
@@ -366,7 +377,13 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 			//fmt.Println("Scope.Pos:", p.Fset.Position(v.Scope().Pos()))
 			def = e.funcs[v.FullName()]
 
-		// TODO(jchen): case *types.Const:
+		case *types.Const:
+			// TODO(jchen): support "-verbose" flag
+			//fmt.Printf("---> %T\n", obj)
+			//fmt.Println("Use:", ident)
+			//fmt.Println("iPos:", ipos)
+			//fmt.Println("vPos:", p.Fset.Position(v.Pos()))
+			def = e.consts[v.Pos()]
 
 		case *types.Var:
 			// TODO(jchen): support "-verbose" flag

--- a/export/exporter.go
+++ b/export/exporter.go
@@ -49,6 +49,7 @@ func Export(workspace string, excludeContent bool, w io.Writer, toolInfo protoco
 		consts: make(map[token.Pos]*defInfo),
 		vars:   make(map[token.Pos]*defInfo),
 		types:  make(map[string]*defInfo),
+		labels: make(map[token.Pos]*defInfo),
 		refs:   make(map[string]*refResultInfo),
 	}).export(toolInfo)
 }
@@ -66,6 +67,7 @@ type exporter struct {
 	consts map[token.Pos]*defInfo    // Keys: definition position
 	vars   map[token.Pos]*defInfo    // Keys: definition position
 	types  map[string]*defInfo       // Keys: type name
+	labels map[token.Pos]*defInfo    // Keys: definition position
 	refs   map[string]*refResultInfo // Keys: definition range ID
 }
 
@@ -320,7 +322,16 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 				contents:    contents,
 			}
 
-		// TODO(jchen): case *types.Label:
+		case *types.Label:
+			// TODO(jchen): support "-verbose" flag
+			//fmt.Printf("---> %T\n", obj)
+			//fmt.Println("Def:", ident.Name)
+			//fmt.Println("iPos:", ipos)
+			e.labels[ident.Pos()] = &defInfo{
+				rangeID:     rangeID,
+				resultSetID: refResult.resultSetID,
+				contents:    contents,
+			}
 
 		// TODO(jchen): case *types.PkgName:
 
@@ -406,7 +417,13 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 			//fmt.Println("Pos:", ipos)
 			def = e.types[obj.Type().String()]
 
-		// TODO(jchen): case *types.Label:
+		case *types.Label:
+			// TODO(jchen): support "-verbose" flag
+			//fmt.Printf("---> %T\n", obj)
+			//fmt.Println("Use:", ident.Name)
+			//fmt.Println("iPos:", ipos)
+			//fmt.Println("vPos:", p.Fset.Position(v.Pos()))
+			def = e.labels[v.Pos()]
 
 		// TODO(jchen): case *types.PkgName:
 


### PR DESCRIPTION
Added more support for object types:

1. `*types.Const`
2. `*types.Label`
3. `*types.PkgName` for only renamed import path, e.g. `doc "github.com/slimsag/godocmd"`