### PR TITLE
Support verbose and debug flags

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -5,8 +5,9 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
+
+	"github.com/sourcegraph/lsif-go/log"
 )
 
 // command is a subcommand handler and its flag set.
@@ -48,6 +49,11 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 		flagSet.Usage()
 		os.Exit(0)
 	}
+
+	if *verbose {
+		log.SetLevel(log.Info)
+	}
+	log.SetDebugMods(*debug)
 
 	// Configure default usage funcs for commands
 	for _, cmd := range c {

--- a/cmd.go
+++ b/cmd.go
@@ -53,7 +53,9 @@ func (c commander) run(flagSet *flag.FlagSet, cmdName, usageText string, args []
 	if *verbose {
 		log.SetLevel(log.Info)
 	}
-	log.SetDebugMods(*debug)
+	if *debug {
+		log.SetLevel(log.Debug)
+	}
 
 	// Configure default usage funcs for commands
 	for _, cmd := range c {

--- a/export.go
+++ b/export.go
@@ -3,11 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 	"os"
 	"time"
 
 	"github.com/sourcegraph/lsif-go/export"
+	"github.com/sourcegraph/lsif-go/log"
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 

--- a/export.go
+++ b/export.go
@@ -44,7 +44,7 @@ Examples:
 		}
 		defer out.Close()
 
-		err = export.Export(*workspaceFlag, *excludeContentFlag, out,
+		s, err := export.Export(*workspaceFlag, *excludeContentFlag, out,
 			protocol.ToolInfo{
 				Name:    "lsif-go",
 				Version: version,
@@ -54,6 +54,7 @@ Examples:
 			return fmt.Errorf("export: %v", err)
 		}
 
+		log.Printf("%d package(s), %d file(s), %d def(s), %d element(s)", s.NumPkgs, s.NumFiles, s.NumDefs, s.NumElements)
 		log.Println("Processed in", time.Since(start))
 		return nil
 	}

--- a/export/exporter.go
+++ b/export/exporter.go
@@ -251,6 +251,7 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			return fmt.Errorf(`emit "next": %v`, err)
 		}
 
+		// TODO(jchen): make the following block of code to function "findContents".
 		qf := func(*types.Package) string { return "" }
 		var s string
 		var extra string
@@ -292,11 +293,9 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 
 		switch v := obj.(type) {
 		case *types.Func:
-			log.Debugf("func", "---> %T\n", obj)
-			log.Debugln("func", "Def:", ident.Name)
-			log.Debugln("func", "FullName:", v.FullName())
-			log.Debugln("func", "iPos:", ipos)
-			log.Debugln("func", "vPos:", p.Fset.Position(v.Pos()))
+			log.Debugln("[func] Def:", ident.Name)
+			log.Debugln("[func] FullName:", v.FullName())
+			log.Debugln("[func] iPos:", ipos)
 			e.funcs[v.FullName()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
@@ -304,9 +303,8 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			}
 
 		case *types.Const:
-			log.Debugf("const", "---> %T\n", obj)
-			log.Debugln("const", "Def:", ident.Name)
-			log.Debugln("const", "iPos:", ipos)
+			log.Debugln("[const] Def:", ident.Name)
+			log.Debugln("[const] iPos:", ipos)
 			e.consts[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
@@ -314,9 +312,8 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			}
 
 		case *types.Var:
-			log.Debugf("var", "---> %T\n", obj)
-			log.Debugln("var", "Def:", ident.Name)
-			log.Debugln("var", "iPos:", ipos)
+			log.Debugln("[var] Def:", ident.Name)
+			log.Debugln("[var] iPos:", ipos)
 			e.vars[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
@@ -324,9 +321,9 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			}
 
 		case *types.TypeName:
-			log.Debugf("typename", "Def:", ident.Name)
-			log.Debugln("typename", "Type:", obj.Type())
-			log.Debugln("typename", "iPos:", ipos)
+			log.Debugln("[typename] Def:", ident.Name)
+			log.Debugln("[typename] Type:", obj.Type())
+			log.Debugln("[typename] iPos:", ipos)
 			e.types[obj.Type().String()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
@@ -334,9 +331,8 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			}
 
 		case *types.Label:
-			log.Debugf("label", "---> %T\n", obj)
-			log.Debugln("label", "Def:", ident.Name)
-			log.Debugln("label", "iPos:", ipos)
+			log.Debugln("[label] Def:", ident.Name)
+			log.Debugln("[label] iPos:", ipos)
 			e.labels[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
@@ -345,9 +341,8 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 
 		case *types.PkgName:
 			// TODO: support import paths are not renamed
-			log.Debugf("pkgname", "---> %T\n", obj)
-			log.Debugln("pkgname", "Use:", ident)
-			log.Debugln("pkgname", "iPos:", ipos)
+			log.Debugln("[pkgname] Use:", ident)
+			log.Debugln("[pkgname] iPos:", ipos)
 			e.imports[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
@@ -355,10 +350,9 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			}
 
 		default:
-			log.Debugf("default", "---> %T\n", obj)
-			log.Debugln("default", "(default)")
-			log.Debugln("default", "Def:", ident)
-			log.Debugln("default", "iPos:", ipos)
+			log.Debugf("[default] ---> %T\n", obj)
+			log.Debugln("[default] Def:", ident)
+			log.Debugln("[default] iPos:", ipos)
 			continue
 		}
 
@@ -392,45 +386,39 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 		var def *defInfo
 		switch v := obj.(type) {
 		case *types.Func:
-			log.Debugf("func", "---> %T\n", obj)
-			log.Debugln("func", "Use:", ident.Name)
-			log.Debugln("func", "FullName:", v.FullName())
-			log.Debugln("func", "iPos:", ipos)
+			log.Debugln("[func] Use:", ident.Name)
+			log.Debugln("[func] FullName:", v.FullName())
+			log.Debugln("[func] iPos:", ipos)
 			def = e.funcs[v.FullName()]
 
 		case *types.Const:
-			log.Debugf("const", "---> %T\n", obj)
-			log.Debugln("const", "Use:", ident)
-			log.Debugln("const", "iPos:", ipos)
-			log.Debugln("const", "vPos:", p.Fset.Position(v.Pos()))
+			log.Debugln("[const] Use:", ident)
+			log.Debugln("[const] iPos:", ipos)
+			log.Debugln("[const] vPos:", p.Fset.Position(v.Pos()))
 			def = e.consts[v.Pos()]
 
 		case *types.Var:
-			log.Debugf("var", "---> %T\n", obj)
-			log.Debugln("var", "Use:", ident)
-			log.Debugln("var", "iPos:", ipos)
-			log.Debugln("var", "vPos:", p.Fset.Position(v.Pos()))
+			log.Debugln("[var] Use:", ident)
+			log.Debugln("[var] iPos:", ipos)
+			log.Debugln("[var] vPos:", p.Fset.Position(v.Pos()))
 			def = e.vars[v.Pos()]
 
 		case *types.TypeName:
-			log.Debugf("typename", "---> %T\n", obj)
-			log.Debugln("typename", "Use:", ident.Name)
-			log.Debugln("typename", "Type:", obj.Type())
-			log.Debugln("typename", "iPos:", ipos)
+			log.Debugln("[typename] Use:", ident.Name)
+			log.Debugln("[typename] Type:", obj.Type())
+			log.Debugln("[typename] iPos:", ipos)
 			def = e.types[obj.Type().String()]
 
 		case *types.Label:
-			log.Debugf("label", "---> %T\n", obj)
-			log.Debugln("label", "Use:", ident.Name)
-			log.Debugln("label", "iPos:", ipos)
-			log.Debugln("label", "vPos:", p.Fset.Position(v.Pos()))
+			log.Debugln("[label] Use:", ident.Name)
+			log.Debugln("[label] iPos:", ipos)
+			log.Debugln("[label] vPos:", p.Fset.Position(v.Pos()))
 			def = e.labels[v.Pos()]
 
 		case *types.PkgName:
-			log.Debugf("pkgname", "---> %T\n", obj)
-			log.Debugln("pkgname", "Use:", ident)
-			log.Debugln("pkgname", "iPos:", ipos)
-			log.Debugln("pkgname", "vPos:", p.Fset.Position(v.Pos()))
+			log.Debugln("[pkgname] Use:", ident)
+			log.Debugln("[pkgname] iPos:", ipos)
+			log.Debugln("[pkgname] vPos:", p.Fset.Position(v.Pos()))
 			def = e.imports[v.Pos()]
 
 		// TODO(jchen): case *types.Builtin:
@@ -438,11 +426,9 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 		// TODO(jchen): case *types.Nil:
 
 		default:
-			log.Debugf("default", "---> %T\n", obj)
-			log.Debugln("default", "(default)")
-			log.Debugln("default", "Use:", ident)
-			log.Debugln("default", "iPos:", ipos)
-			log.Debugln("default", "vPos:", p.Fset.Position(v.Pos()))
+			log.Debugln("[default] Use:", ident)
+			log.Debugln("[default] iPos:", ipos)
+			log.Debugln("[default] vPos:", p.Fset.Position(v.Pos()))
 			continue
 		}
 

--- a/log/log.go
+++ b/log/log.go
@@ -2,7 +2,6 @@ package log
 
 import (
 	"log"
-	"strings"
 )
 
 func init() {
@@ -10,8 +9,10 @@ func init() {
 	log.SetPrefix("")
 }
 
+// Level determines the level of verbose for logging messages.
 type Level int
 
+// Logging levels can be used to define verboseness.
 const (
 	Debug Level = iota
 	Info
@@ -20,52 +21,33 @@ const (
 
 var level = None
 
+// SetLevel sets the logging level.
 func SetLevel(l Level) {
 	level = l
 }
 
-var (
-	debugAll  = false
-	debugMods map[string]bool
-)
-
-func SetDebugMods(mods string) {
-	if mods == "none" {
-		return
-	}
-	level = Debug
-
-	if mods == "all" {
-		debugAll = true
-		return
-	}
-
-	debugMods = make(map[string]bool)
-	for _, m := range strings.Split(mods, ",") {
-		debugMods[m] = true
-	}
-}
-
-func Debugf(mod, format string, v ...interface{}) {
+// Debugf prints logging messages in Debug level.
+// Arguments are handled in the manner of fmt.Printf.
+func Debugf(format string, v ...interface{}) {
 	if level > Debug {
-		return
-	} else if !debugAll && !debugMods[mod] {
 		return
 	}
 
 	log.Printf(format, v...)
 }
 
-func Debugln(mod string, v ...interface{}) {
+// Debugf prints logging messages in Debug level.
+// Arguments are handled in the manner of fmt.Println.
+func Debugln(v ...interface{}) {
 	if level > Debug {
-		return
-	} else if !debugAll && !debugMods[mod] {
 		return
 	}
 
 	log.Println(v...)
 }
 
+// Infof prints logging messages in Info level.
+// Arguments are handled in the manner of fmt.Printf.
 func Infof(format string, v ...interface{}) {
 	if level > Info {
 		return
@@ -74,6 +56,8 @@ func Infof(format string, v ...interface{}) {
 	log.Printf(format, v...)
 }
 
+// Infoln prints logging messages in Info level.
+// Arguments are handled in the manner of fmt.Println.
 func Infoln(v ...interface{}) {
 	if level > Info {
 		return

--- a/log/log.go
+++ b/log/log.go
@@ -2,11 +2,13 @@ package log
 
 import (
 	"log"
+	"os"
 )
 
 func init() {
 	log.SetFlags(0)
 	log.SetPrefix("")
+	log.SetOutput(os.Stdout)
 }
 
 // Level determines the level of verbose for logging messages.

--- a/log/log.go
+++ b/log/log.go
@@ -1,0 +1,83 @@
+package log
+
+import (
+	"log"
+	"strings"
+)
+
+func init() {
+	log.SetFlags(0)
+	log.SetPrefix("")
+}
+
+type Level int
+
+const (
+	Debug Level = iota
+	Info
+	None Level = 99
+)
+
+var level = None
+
+func SetLevel(l Level) {
+	level = l
+}
+
+var (
+	debugAll  = false
+	debugMods map[string]bool
+)
+
+func SetDebugMods(mods string) {
+	if mods == "none" {
+		return
+	}
+	level = Debug
+
+	if mods == "all" {
+		debugAll = true
+		return
+	}
+
+	debugMods = make(map[string]bool)
+	for _, m := range strings.Split(mods, ",") {
+		debugMods[m] = true
+	}
+}
+
+func Debugf(mod, format string, v ...interface{}) {
+	if level > Debug {
+		return
+	} else if !debugAll && !debugMods[mod] {
+		return
+	}
+
+	log.Printf(format, v...)
+}
+
+func Debugln(mod string, v ...interface{}) {
+	if level > Debug {
+		return
+	} else if !debugAll && !debugMods[mod] {
+		return
+	}
+
+	log.Println(v...)
+}
+
+func Infof(format string, v ...interface{}) {
+	if level > Info {
+		return
+	}
+
+	log.Printf(format, v...)
+}
+
+func Infoln(v ...interface{}) {
+	if level > Info {
+		return
+	}
+
+	log.Println(v...)
+}

--- a/log/wrap.go
+++ b/log/wrap.go
@@ -1,0 +1,23 @@
+package log
+
+import "log"
+
+func Print(v ...interface{}) {
+	log.Print(v...)
+}
+
+func Printf(format string, v ...interface{}) {
+	log.Printf(format, v...)
+}
+
+func Println(v ...interface{}) {
+	log.Println(v...)
+}
+
+func Fatal(v ...interface{}) {
+	log.Fatal(v...)
+}
+
+func Fatalf(format string, v ...interface{}) {
+	log.Fatalf(format, v...)
+}

--- a/log/wrap.go
+++ b/log/wrap.go
@@ -2,22 +2,35 @@ package log
 
 import "log"
 
+/*
+	This file serves the purpose of wrapping used functions from standard library "log"
+	to simplify import.
+*/
+
+// Print calls Output to print to the standard logger.
+// Arguments are handled in the manner of fmt.Print.
 func Print(v ...interface{}) {
 	log.Print(v...)
 }
 
+// Printf calls Output to print to the standard logger.
+// Arguments are handled in the manner of fmt.Printf.
 func Printf(format string, v ...interface{}) {
 	log.Printf(format, v...)
 }
 
+// Println calls Output to print to the standard logger.
+// Arguments are handled in the manner of fmt.Println.
 func Println(v ...interface{}) {
 	log.Println(v...)
 }
 
+// Fatal is equivalent to Print() followed by a call to os.Exit(1).
 func Fatal(v ...interface{}) {
 	log.Fatal(v...)
 }
 
+// Fatalf is equivalent to Printf() followed by a call to os.Exit(1).
 func Fatalf(format string, v ...interface{}) {
 	log.Fatalf(format, v...)
 }

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 
 import (
 	"flag"
-	"log"
 	"os"
 )
 
@@ -15,6 +14,8 @@ Usage:
 	lsif-go [options] command [command options]
 
 The options are:
+	debug           display debug information
+	verbose         display verbose information
 
 The commands are:
 
@@ -28,10 +29,11 @@ Use "lsif-go [command] -h" for more information about a command.
 // commands contains all registered subcommands.
 var commands commander
 
-func main() {
-	// Configure logging
-	log.SetFlags(0)
-	log.SetPrefix("")
+var (
+	debug   = flag.String("debug", "none", `To display debug information.`)
+	verbose = flag.Bool("verbose", false, `To display verbose information.`)
+)
 
+func main() {
 	commands.run(flag.CommandLine, "lsif-go", usageText, os.Args[1:])
 }

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ Use "lsif-go [command] -h" for more information about a command.
 var commands commander
 
 var (
-	debug   = flag.String("debug", "none", `To display debug information.`)
+	debug   = flag.Bool("debug", false, `To display debug information.`)
 	verbose = flag.Bool("verbose", false, `To display verbose information.`)
 )
 

--- a/version.go
+++ b/version.go
@@ -3,8 +3,8 @@ package main
 import (
 	"flag"
 	"fmt"
-	"log"
 
+	"github.com/sourcegraph/lsif-go/log"
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 


### PR DESCRIPTION
Remove all comments about "-verbose" flag support. 
Now has both "-verbose" and "-debug" flags added.

At current:
- "-verbose": print packages and files found
- "-debug": print each def and use info found

Little extra, add simple statistics report about how many things being processed:

```
4 package(s), 10 file(s), 539 def(s), 10020 element(s)
Processed in 752.063422ms
```