### PR TITLE
export: remove unnecessary contents filed in defInfo

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -225,6 +225,12 @@ func (e *exporter) addImports(p *packages.Package, f *ast.File, fi *fileInfo) er
 		// for any possible consumers. We use trimmed version here only when we need to
 		// (trimmed version as a map key or an argument).
 		ipath := strings.Trim(ispec.Path.Value, `"`)
+		if p.Imports[ipath] == nil {
+			// There is no package information if the package cannot be located from the
+			// file system (i.e. missing files of a dependency).
+			continue
+		}
+
 		var name string
 		if ispec.Name == nil {
 			name = ispec.Path.Value

--- a/export/exporter.go
+++ b/export/exporter.go
@@ -290,11 +290,6 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			return fmt.Errorf(`emit "next": %v`, err)
 		}
 
-		contents, err := findContents(f, obj)
-		if err != nil {
-			return fmt.Errorf("find contents: %v", err)
-		}
-
 		switch v := obj.(type) {
 		case *types.Func:
 			log.Debugln("[func] Def:", ident.Name)
@@ -303,7 +298,6 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			e.funcs[v.FullName()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
-				contents:    contents,
 			}
 
 		case *types.Const:
@@ -312,7 +306,6 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			e.consts[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
-				contents:    contents,
 			}
 
 		case *types.Var:
@@ -321,7 +314,6 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			e.vars[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
-				contents:    contents,
 			}
 
 		case *types.TypeName:
@@ -331,7 +323,6 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			e.types[obj.Type().String()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
-				contents:    contents,
 			}
 
 		case *types.Label:
@@ -340,7 +331,6 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			e.labels[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
-				contents:    contents,
 			}
 
 		case *types.PkgName:
@@ -349,7 +339,6 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			e.imports[ident.Pos()] = &defInfo{
 				rangeID:     rangeID,
 				resultSetID: refResult.resultSetID,
-				contents:    contents,
 			}
 
 		default:
@@ -357,6 +346,11 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 			log.Debugln("[default] Def:", ident)
 			log.Debugln("[default] iPos:", ipos)
 			continue
+		}
+
+		contents, err := findContents(f, obj)
+		if err != nil {
+			return fmt.Errorf("find contents: %v", err)
 		}
 
 		hoverResultID, err := e.emitHoverResult(contents)

--- a/export/types.go
+++ b/export/types.go
@@ -1,9 +1,5 @@
 package export
 
-import (
-	"github.com/sourcegraph/lsif-go/protocol"
-)
-
 // fileInfo contains LSIF information of a file.
 type fileInfo struct {
 	// The vertex ID of the document that represents the file.
@@ -22,8 +18,6 @@ type defInfo struct {
 	rangeID string
 	// The vertex ID of the resultSet that represents the definition.
 	resultSetID string
-	// The contents will be used as the hover information.
-	contents []protocol.MarkedString
 	// The lazily initialized definition result ID upon first use found.
 	defResultID string
 }


### PR DESCRIPTION
Before, we compute value of `defInfo.contents` field and added it in memory cache because we wanted it to be used later for hoverinfo in `exportUses`.

But since https://github.com/sourcegraph/lsif-go/commit/288a3b1c15bbb3025452bcd4e40b0c5ab3ca9d48, the only place uses "contents" field is right after where its value is computed, thus there is no need for caching "contents" in memory anymore.