### PR TITLE
Emit item edges only once.

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -461,11 +461,11 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 			}
 
 			def.defResultID = defResultID
-		}
 
-		_, err = e.emitItem(def.defResultID, []string{def.rangeID}, fi.docID)
-		if err != nil {
-			return fmt.Errorf(`emit "item": %v`, err)
+			_, err = e.emitItem(def.defResultID, []string{def.rangeID}, fi.docID)
+			if err != nil {
+				return fmt.Errorf(`emit "item": %v`, err)
+			}
 		}
 
 		refResult := e.refs[def.rangeID]


### PR DESCRIPTION
I'm not convinced this is correct, but the old behavior would duplicate item edges between a range and a result set MANY times.

Could someone confirm that this is sufficient to emit the edge correctly still?