### PR TITLE
Fix bad document field value on item edges.

### DIFF
--- a/export/exporter.go
+++ b/export/exporter.go
@@ -121,7 +121,7 @@ func (e *exporter) export(info protocol.ToolInfo) (*Stats, error) {
 				}
 			}
 
-			for docID, rangeIDs := range e.refs[rangeID].defRangeIDs {
+			for docID, rangeIDs := range e.refs[rangeID].refRangeIDs {
 				_, err = e.emitItemOfReferences(refResultID, rangeIDs, docID)
 				if err != nil {
 					return nil, fmt.Errorf(`emit "item": %v`, err)

--- a/export/exporter.go
+++ b/export/exporter.go
@@ -114,13 +114,15 @@ func (e *exporter) export(info protocol.ToolInfo) (*Stats, error) {
 				return nil, fmt.Errorf(`emit "textDocument/references": %v`, err)
 			}
 
-			_, err = e.emitItemOfDefinitions(refResultID, e.refs[rangeID].defRangeIDs, f.docID)
-			if err != nil {
-				return nil, fmt.Errorf(`emit "item": %v`, err)
+			for docID, rangeIDs := range e.refs[rangeID].defRangeIDs {
+				_, err = e.emitItemOfDefinitions(refResultID, rangeIDs, docID)
+				if err != nil {
+					return nil, fmt.Errorf(`emit "item": %v`, err)
+				}
 			}
 
-			if len(e.refs[rangeID].refRangeIDs) > 0 {
-				_, err = e.emitItemOfReferences(refResultID, e.refs[rangeID].refRangeIDs, f.docID)
+			for docID, rangeIDs := range e.refs[rangeID].defRangeIDs {
+				_, err = e.emitItemOfReferences(refResultID, rangeIDs, docID)
 				if err != nil {
 					return nil, fmt.Errorf(`emit "item": %v`, err)
 				}
@@ -272,11 +274,19 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 
 		refResult, ok := e.refs[rangeID]
 		if !ok {
-			refResult = &refResultInfo{resultSetID: e.nextID()}
+			refResult = &refResultInfo{
+				resultSetID: e.nextID(),
+				defRangeIDs: map[string][]string{},
+				refRangeIDs: map[string][]string{},
+			}
+
 			e.refs[rangeID] = refResult
 		}
 
-		refResult.defRangeIDs = append(refResult.defRangeIDs, rangeID)
+		if _, ok := refResult.defRangeIDs[fi.docID]; !ok {
+			refResult.defRangeIDs[fi.docID] = []string{}
+		}
+		refResult.defRangeIDs[fi.docID] = append(refResult.defRangeIDs[fi.docID], rangeID)
 
 		if !ok {
 			err = e.emit(protocol.NewResultSet(refResult.resultSetID))
@@ -291,6 +301,7 @@ func (e *exporter) exportDefs(p *packages.Package, f *ast.File, fi *fileInfo, pr
 		}
 
 		defInfo := &defInfo{
+			docID:       fi.docID,
 			rangeID:     rangeID,
 			resultSetID: refResult.resultSetID,
 		}
@@ -461,7 +472,7 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 
 			def.defResultID = defResultID
 
-			_, err = e.emitItem(def.defResultID, []string{def.rangeID}, fi.docID)
+			_, err = e.emitItem(def.defResultID, []string{def.rangeID}, def.docID)
 			if err != nil {
 				return fmt.Errorf(`emit "item": %v`, err)
 			}
@@ -469,7 +480,10 @@ func (e *exporter) exportUses(p *packages.Package, fi *fileInfo, filename string
 
 		refResult := e.refs[def.rangeID]
 		if refResult != nil {
-			refResult.refRangeIDs = append(refResult.refRangeIDs, rangeID)
+			if _, ok := refResult.refRangeIDs[fi.docID]; !ok {
+				refResult.refRangeIDs[fi.docID] = []string{}
+			}
+			refResult.refRangeIDs[fi.docID] = append(refResult.refRangeIDs[fi.docID], rangeID)
 		}
 	}
 

--- a/export/types.go
+++ b/export/types.go
@@ -15,7 +15,8 @@ type fileInfo struct {
 // defInfo contains LSIF information of a definition.
 type defInfo struct {
 	// The identifier of the containing document. This is necessary
-	// to track when emitting item edges sthat
+	// to track when emitting item edges as we need to store the
+	// document to which it belongs (not where it is referenced).
 	docID string
 	// The vertex ID of the range that represents the definition.
 	rangeID string

--- a/export/types.go
+++ b/export/types.go
@@ -14,6 +14,9 @@ type fileInfo struct {
 
 // defInfo contains LSIF information of a definition.
 type defInfo struct {
+	// The identifier of the containing document. This is necessary
+	// to track when emitting item edges sthat
+	docID string
 	// The vertex ID of the range that represents the definition.
 	rangeID string
 	// The vertex ID of the resultSet that represents the definition.
@@ -27,9 +30,11 @@ type refResultInfo struct {
 	// The vertex ID of the resultSet that represents the referenceResult.
 	resultSetID string
 	// The vertices ID of definition ranges that are referenced by the referenceResult.
+	// This is a map from the document ID to the set of range IDs contained within it.
 	// This information is collected to emit `{"label":"item", "property":"definitions"}` edge.
-	defRangeIDs []string
+	defRangeIDs map[string][]string
 	// The vertices ID of reference ranges that are represented by the referenceResult.
+	// This is a map from the document ID to the set of range IDs contained within it.
 	// This information is collected to emit `{"label":"item", "property":"references"}` edge.
-	refRangeIDs []string
+	refRangeIDs map[string][]string
 }


### PR DESCRIPTION
The `document` property on `item` edges refers to the containing document of the `inVs` values, not the `outV` value. @chrismwendt and I found this out the hard way playing with the C++ indexer.