### PR TITLE
Fix monikers

### DIFF
--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -50,12 +50,12 @@ func realMain() error {
 		return fmt.Errorf("either an output file using --out or --stdout must be specified")
 	}
 
-	if debug {
-		log.SetLevel(log.Debug)
-	}
-
 	if verbose {
 		log.SetLevel(log.Info)
+	}
+
+	if debug {
+		log.SetLevel(log.Debug)
 	}
 
 	if stdout && (verbose || debug) {

--- a/cmd/lsif-gomod/main.go
+++ b/cmd/lsif-gomod/main.go
@@ -55,7 +55,7 @@ func realMain() error {
 	if moduleVersion == "" {
 		// For future reference, see
 		// https://github.com/golang/vgo/blob/9d567625acf4c5e156b9890bf6feb16eb9fa5c51/vendor/cmd/go/internal/modfetch/coderepo.go#L88
-		return fmt.Errorf("module version cannot be inferred")
+		return fmt.Errorf("module version cannot be inferred so set it explicitly with -moduleVersion=...")
 	}
 
 	var in io.Reader

--- a/cmd/lsif-gomod/main.go
+++ b/cmd/lsif-gomod/main.go
@@ -23,15 +23,17 @@ func main() {
 
 func realMain() error {
 	var (
-		projectRoot string
-		inFile      string
-		stdin       bool
-		outFile     string
-		stdout      bool
+		projectRoot   string
+		moduleVersion string
+		inFile        string
+		stdin         bool
+		outFile       string
+		stdout        bool
 	)
 
 	app := kingpin.New("lsif-gomod", "lsif-gomod decorates lsif-go output with gomod monikers.").Version(versionString)
 	app.Flag("projectRoot", "Specifies the project root. Defaults to the current working directory.").Default(".").StringVar(&projectRoot)
+	app.Flag("moduleVersion", "Specifies the version of the module defined by this project.").StringVar(&moduleVersion)
 	app.Flag("in", "Specifies the file that contains a LSIF dump.").StringVar(&inFile)
 	app.Flag("stdin", "Reads the dump from stdin.").Default("false").BoolVar(&stdin)
 	app.Flag("out", "The output file the converted dump is saved to.").StringVar(&outFile)
@@ -48,6 +50,12 @@ func realMain() error {
 
 	if outFile == "" && !stdout {
 		return fmt.Errorf("either an output file using --out or --stdout must be specified")
+	}
+
+	if moduleVersion == "" {
+		// For future reference, see
+		// https://github.com/golang/vgo/blob/9d567625acf4c5e156b9890bf6feb16eb9fa5c51/vendor/cmd/go/internal/modfetch/coderepo.go#L88
+		return fmt.Errorf("module version cannot be inferred")
 	}
 
 	var in io.Reader
@@ -76,5 +84,5 @@ func realMain() error {
 		out = file
 	}
 
-	return gomod.Decorate(in, out, projectRoot)
+	return gomod.Decorate(in, out, projectRoot, moduleVersion)
 }

--- a/gomod/decorate.go
+++ b/gomod/decorate.go
@@ -14,15 +14,11 @@ const MaxToken = 1024 * 1024 * 1024
 // Lines will only be added, not modified or deleted. Each import or export
 // moniker for which there is information in the project's go.mod/go.sum will
 // be decorated.
-func Decorate(in io.Reader, out io.Writer, projectRoot string) error {
+func Decorate(in io.Reader, out io.Writer, projectRoot, moduleVersion string) error {
 	packageName, err := readModFile(projectRoot)
 	if err != nil {
 		return err
 	}
-
-	// TODO - need to find this from git checkout
-	// https://github.com/golang/vgo/blob/9d567625acf4c5e156b9890bf6feb16eb9fa5c51/vendor/cmd/go/internal/modfetch/coderepo.go#L88
-	packageVersion := "0.0.0"
 
 	dependencies, err := readSumFile(projectRoot)
 	if err != nil {
@@ -31,7 +27,7 @@ func Decorate(in io.Reader, out io.Writer, projectRoot string) error {
 
 	scanner := bufio.NewScanner(in)
 	scanner.Buffer(make([]byte, MaxToken), MaxToken)
-	decorator := newDecorator(out, packageName, packageVersion, dependencies)
+	decorator := newDecorator(out, packageName, moduleVersion, dependencies)
 
 	for scanner.Scan() {
 		// Always write original line

--- a/gomod/moniker.go
+++ b/gomod/moniker.go
@@ -4,17 +4,18 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/google/uuid"
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 
 type decorator struct {
-	encoder              *json.Encoder
-	packageName          string
-	packageVersion       string
-	dependencies         map[string]string
-	packageInformationID string
+	encoder               *json.Encoder
+	packageName           string
+	packageVersion        string
+	dependencies          map[string]string
+	packageInformationIDs map[string]string
 }
 
 type moniker struct {
@@ -28,10 +29,11 @@ type moniker struct {
 
 func newDecorator(out io.Writer, packageName, packageVersion string, dependencies map[string]string) *decorator {
 	return &decorator{
-		packageName:    packageName,
-		packageVersion: packageVersion,
-		dependencies:   dependencies,
-		encoder:        json.NewEncoder(out),
+		packageName:           packageName,
+		packageVersion:        packageVersion,
+		dependencies:          dependencies,
+		packageInformationIDs: map[string]string{},
+		encoder:               json.NewEncoder(out),
 	}
 }
 
@@ -59,32 +61,45 @@ func (d *decorator) decorate(line string) error {
 }
 
 func (d *decorator) addImportMoniker(moniker *moniker) error {
-	version, ok := d.dependencies[moniker.Identifier]
-	if !ok {
-		return nil
+	for _, packageName := range packagePrefixes(strings.Split(moniker.Identifier, ":")[0]) {
+		packageVersion, ok := d.dependencies[packageName]
+		if !ok {
+			continue
+		}
+
+		packageInformationID, err := d.ensurePackageInformation(packageName, packageVersion)
+		if err != nil {
+			return err
+		}
+
+		return d.addMonikers("import", moniker.Identifier, moniker.ID, packageInformationID)
 	}
 
-	packageInformationID := uuid.New().String()
-	vertex := protocol.NewPackageInformation(packageInformationID, moniker.Identifier, "gomod", version)
-	if err := d.encoder.Encode(vertex); err != nil {
-		return err
-	}
-
-	return d.addMonikers("import", moniker.Identifier, moniker.ID, packageInformationID)
+	return nil
 }
 
 func (d *decorator) addExportMoniker(moniker *moniker) error {
-	// If we haven't exported our own package information, do so now.
-	// If the vertex is needed again later, we can use the same identifier.
-	if d.packageInformationID == "" {
-		d.packageInformationID = uuid.New().String()
-		vertex := protocol.NewPackageInformation(d.packageInformationID, d.packageName, "gomod", d.packageVersion)
-		if err := d.encoder.Encode(vertex); err != nil {
-			return err
-		}
+	packageInformationID, err := d.ensurePackageInformation(d.packageName, d.packageVersion)
+	if err != nil {
+		return err
 	}
 
-	return d.addMonikers("export", moniker.Identifier, moniker.ID, d.packageInformationID)
+	return d.addMonikers("export", moniker.Identifier, moniker.ID, packageInformationID)
+}
+
+func (d *decorator) ensurePackageInformation(packageName, version string) (string, error) {
+	packageInformationID, ok := d.packageInformationIDs[packageName]
+	if !ok {
+		packageInformationID = uuid.New().String()
+		vertex := protocol.NewPackageInformation(packageInformationID, packageName, "gomod", version)
+		if err := d.encoder.Encode(vertex); err != nil {
+			return "", err
+		}
+
+		d.packageInformationIDs[packageName] = packageInformationID
+	}
+
+	return packageInformationID, nil
 }
 
 // addMonikers outputs a "gomod" moniker vertex, attaches the given package vertex
@@ -107,4 +122,15 @@ func (d *decorator) addMonikers(kind string, identifier string, sourceID, packag
 	}
 
 	return nil
+}
+
+func packagePrefixes(packageName string) []string {
+	parts := strings.Split(packageName, "/")
+	prefixes := make([]string, len(parts))
+
+	for i := 1; i <= len(parts); i++ {
+		prefixes[len(parts)-i] = strings.Join(parts[:i], "/")
+	}
+
+	return prefixes
 }

--- a/gomod/moniker.go
+++ b/gomod/moniker.go
@@ -13,7 +13,7 @@ import (
 type decorator struct {
 	encoder               *json.Encoder
 	packageName           string
-	packageVersion        string
+	moduleVersion         string
 	dependencies          map[string]string
 	packageInformationIDs map[string]string
 }
@@ -27,10 +27,10 @@ type moniker struct {
 	Identifier string               `json:"identifier"`
 }
 
-func newDecorator(out io.Writer, packageName, packageVersion string, dependencies map[string]string) *decorator {
+func newDecorator(out io.Writer, packageName, moduleVersion string, dependencies map[string]string) *decorator {
 	return &decorator{
 		packageName:           packageName,
-		packageVersion:        packageVersion,
+		moduleVersion:         moduleVersion,
 		dependencies:          dependencies,
 		packageInformationIDs: map[string]string{},
 		encoder:               json.NewEncoder(out),
@@ -79,7 +79,7 @@ func (d *decorator) addImportMoniker(moniker *moniker) error {
 }
 
 func (d *decorator) addExportMoniker(moniker *moniker) error {
-	packageInformationID, err := d.ensurePackageInformation(d.packageName, d.packageVersion)
+	packageInformationID, err := d.ensurePackageInformation(d.packageName, d.moduleVersion)
 	if err != nil {
 		return err
 	}

--- a/index/indexer.go
+++ b/index/indexer.go
@@ -356,7 +356,7 @@ func (e *indexer) indexDefs(p *packages.Package, f *ast.File, fi *fileInfo, proI
 		}
 
 		if ident.IsExported() {
-			err := e.emitMoniker("export", refResult.resultSetID, fmt.Sprintf("%s.%s", p.String(), ident.String()))
+			err := e.emitMoniker("export", refResult.resultSetID, fmt.Sprintf("%s:%s", p.String(), ident.String()))
 			if err != nil {
 				return fmt.Errorf(`emit moniker": %v`, err)
 			}
@@ -443,7 +443,10 @@ func (e *indexer) indexUses(p *packages.Package, fi *fileInfo, filename string) 
 			continue
 		}
 
-		if def == nil {
+		pkg := obj.Pkg()
+		if def == nil && pkg == nil {
+			// No range to emit because have neither a definition nor a moniker to
+			// attach to the range.
 			continue
 		}
 
@@ -452,6 +455,17 @@ func (e *indexer) indexUses(p *packages.Package, fi *fileInfo, filename string) 
 			return fmt.Errorf(`emit "range": %v`, err)
 		}
 		rangeIDs = append(rangeIDs, rangeID)
+
+		if def == nil {
+			// If we don't have a definition in this package, emit an import moniker
+			// so that we can correlate it with another dump's LSIF data.
+			err = e.emitMoniker("import", rangeID, fmt.Sprintf("%s:%s", pkg.Path(), obj.Id()))
+			if err != nil {
+				return fmt.Errorf(`emit moniker": %v`, err)
+			}
+
+			continue
+		}
 
 		_, err = e.emitNext(rangeID, def.resultSetID)
 		if err != nil {

--- a/index/indexer.go
+++ b/index/indexer.go
@@ -27,7 +27,7 @@ func Index(workspace string, excludeContent bool, w io.Writer, toolInfo protocol
 		return nil, fmt.Errorf("get abspath of project root: %v", err)
 	}
 
-	fmt.Println("Loading packages...")
+	log.Infoln("Loading packages...")
 
 	pkgs, err := packages.Load(&packages.Config{
 		Mode: packages.NeedName | packages.NeedFiles |
@@ -39,7 +39,7 @@ func Index(workspace string, excludeContent bool, w io.Writer, toolInfo protocol
 		return nil, fmt.Errorf("load packages: %v", err)
 	}
 
-	fmt.Println("Indexing packages...")
+	log.Infoln("Indexing packages...")
 
 	e := &indexer{
 		projectRoot:    projectRoot,


### PR DESCRIPTION
We were not emitting any data about uses that were not defined inside the package. This change:

- ensures monikers are emitted for such uses
- standardizes moniker format with identifiers (`package:ident`)
- correlates monikers correctly with the package from go.sum (previously required an exact match, not a prefix match)
- does not hardcode a module version of 0.0.0 for defs