### PR TITLE
Fix bad moniker in test files.

### DIFF
--- a/index/indexer.go
+++ b/index/indexer.go
@@ -357,7 +357,7 @@ func (e *indexer) indexDefs(p *packages.Package, f *ast.File, fi *fileInfo, proI
 		}
 
 		if ident.IsExported() {
-			err := e.emitMoniker("export", refResult.resultSetID, fmt.Sprintf("%s:%s", p.String(), ident.String()))
+			err := e.emitMoniker("export", refResult.resultSetID, fmt.Sprintf("%s:%s", p.PkgPath, ident.String()))
 			if err != nil {
 				return fmt.Errorf(`emit moniker": %v`, err)
 			}


### PR DESCRIPTION
Using pkg.String() will create package names like "some package [some package.test]", when we only want the first part.