### PR TITLE
Emit hover results for externally defined uses

### DIFF
--- a/internal/index/helper.go
+++ b/internal/index/helper.go
@@ -11,6 +11,7 @@ import (
 	doc "github.com/slimsag/godocmd"
 	"github.com/sourcegraph/lsif-go/protocol"
 	"golang.org/x/tools/go/ast/astutil"
+	"golang.org/x/tools/go/packages"
 )
 
 // lspRange transforms go/token.Position (1-based) to LSP start and end ranges (0-based)
@@ -23,6 +24,27 @@ func lspRange(pos token.Position, name string) (start protocol.Pos, end protocol
 			Line:      pos.Line - 1,
 			Character: pos.Column - 1 + len(name),
 		}
+}
+
+// externalHoverContents returns contents used as hover info for objects that are not
+// defined in any of the (directly) analyzed source files. This will attempt to find
+// the definition in the AST of the dependency and pull the hover text from that.
+func externalHoverContents(p *packages.Package, obj types.Object, pkg *types.Package) ([]protocol.MarkedString, error) {
+	dependencyPackage := p.Imports[pkg.Path()]
+	if dependencyPackage == nil {
+		return nil, nil
+	}
+
+	for _, f := range dependencyPackage.Syntax {
+		if f.Scope.Lookup(obj.Id()) == nil {
+			// Definition is not in this file of the package
+			continue
+		}
+
+		return findContents(f, obj)
+	}
+
+	return nil, nil
 }
 
 // findContents returns contents used as hover info for given object.

--- a/internal/index/helper.go
+++ b/internal/index/helper.go
@@ -35,6 +35,9 @@ func externalHoverContents(p *packages.Package, obj types.Object, pkg *types.Pac
 		return nil, nil
 	}
 
+	// TODO (efritz) - this only works for some top-level declarations
+	// Does not currently work for fields or functions with receivers.
+
 	for _, f := range dependencyPackage.Syntax {
 		if f.Scope.Lookup(obj.Id()) == nil {
 			// Definition is not in this file of the package

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -606,6 +606,23 @@ func (i *indexer) indexUses(p *packages.Package, fi *fileInfo, filename string) 
 		rangeIDs = append(rangeIDs, rangeID)
 
 		if def == nil {
+			contents, err := externalHoverContents(p, obj, pkg)
+			if err != nil {
+				return err
+			}
+
+			if contents != nil {
+				hoverResultID, err := i.w.EmitHoverResult(contents)
+				if err != nil {
+					return fmt.Errorf(`emit "hoverResult": %v`, err)
+				}
+
+				_, err = i.w.EmitTextDocumentHover(rangeID, hoverResultID)
+				if err != nil {
+					return fmt.Errorf(`emit "textDocument/hover": %v`, err)
+				}
+			}
+
 			// If we don't have a definition in this package, emit an import moniker
 			// so that we can correlate it with another dump's LSIF data.
 			err = i.emitImportMoniker(rangeID, fmt.Sprintf("%s:%s", pkg.Path(), obj.Id()))

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -573,18 +573,14 @@ func (i *indexer) indexUses(p *packages.Package, fi *fileInfo, filename string) 
 			log.Debugln("[pkgname] vPos:", p.Fset.Position(v.Pos()))
 			def = i.imports[v.Pos()]
 
-		// TODO(jchen): case *types.Builtin:
-
-		// TODO(jchen): case *types.Nil:
-
 		default:
 			log.Debugln("[default] Use:", ident)
 			log.Debugln("[default] iPos:", ipos)
 			log.Debugln("[default] vPos:", p.Fset.Position(v.Pos()))
-			continue
 		}
 
 		pkg := obj.Pkg()
+
 		if def == nil && pkg == nil {
 			// No range to emit because have neither a definition nor a moniker to
 			// attach to the range.


### PR DESCRIPTION
This gives us hover text for things we can't jump to such as `time.Millisecond`, `http.Request`, etc. This is a huge benefit, but still needs some work. Things that aren't defined at the top level still don't resolve, but I think it's possible with a little more elbow grease.