### PR TITLE
Ensure project root is always the root of the repository.

### DIFF
--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -26,18 +27,20 @@ func main() {
 
 func realMain() error {
 	var (
-		debug         bool
-		verbose       bool
-		projectRoot   string
-		moduleVersion string
-		noContents    bool
-		outFile       string
+		debug          bool
+		verbose        bool
+		projectRoot    string
+		repositoryRoot string
+		moduleVersion  string
+		noContents     bool
+		outFile        string
 	)
 
 	app := kingpin.New("lsif-go", "lsif-go is an LSIF indexer for Go.").Version(versionString)
 	app.Flag("debug", "Display debug information.").Default("false").BoolVar(&debug)
 	app.Flag("verbose", "Display verbose information.").Short('v').Default("false").BoolVar(&verbose)
 	app.Flag("projectRoot", "Specifies the project root. Defaults to the current working directory.").Default(".").StringVar(&projectRoot)
+	app.Flag("repositoryRoot", "Specifies the repository root.").StringVar(&repositoryRoot)
 	app.Flag("moduleVersion", "Specifies the version of the module defined by this project.").StringVar(&moduleVersion)
 	app.Flag("noContents", "File contents will not be embedded into the dump.").Default("false").BoolVar(&noContents)
 	app.Flag("out", "The output file the dump is saved to.").Default("dump.lsif").StringVar(&outFile)
@@ -58,6 +61,24 @@ func realMain() error {
 	// Print progress dots if we have no other output
 	printProgressDots := !verbose && !debug
 
+	if repositoryRoot == "" {
+		toplevel, err := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+		if err != nil {
+			return fmt.Errorf("get git root: %v", err)
+		}
+		repositoryRoot = string(toplevel)
+	}
+
+	projectRoot, err = filepath.Abs(projectRoot)
+	if err != nil {
+		return fmt.Errorf("get abspath of project root: %v", err)
+	}
+
+	repositoryRoot, err = filepath.Abs(repositoryRoot)
+	if err != nil {
+		return fmt.Errorf("get abspath of repository root: %v", err)
+	}
+
 	moduleName, dependencies, err := gomod.ListModules(projectRoot)
 	if err != nil {
 		return err
@@ -76,11 +97,6 @@ func realMain() error {
 
 	defer out.Close()
 
-	projectRoot, err = filepath.Abs(projectRoot)
-	if err != nil {
-		return fmt.Errorf("get abspath of project root: %v", err)
-	}
-
 	toolInfo := protocol.ToolInfo{
 		Name:    "lsif-go",
 		Version: version,
@@ -89,6 +105,7 @@ func realMain() error {
 
 	indexer := index.NewIndexer(
 		projectRoot,
+		repositoryRoot,
 		moduleName,
 		moduleVersion,
 		dependencies,

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -33,6 +33,7 @@ type Stats struct {
 // indexer keeps track of all information needed to generate an LSIF dump.
 type indexer struct {
 	projectRoot       string
+	repositoryRoot    string
 	printProgressDots bool
 	toolInfo          protocol.ToolInfo
 	w                 *protocol.Writer
@@ -62,6 +63,7 @@ type indexer struct {
 // NewIndexer creates a new Indexer.
 func NewIndexer(
 	projectRoot string,
+	repositoryRoot string,
 	moduleName string,
 	moduleVersion string,
 	dependencies map[string]string,
@@ -72,6 +74,7 @@ func NewIndexer(
 ) Indexer {
 	return &indexer{
 		projectRoot:       projectRoot,
+		repositoryRoot:    repositoryRoot,
 		moduleName:        moduleName,
 		moduleVersion:     moduleVersion,
 		dependencies:      dependencies,
@@ -133,7 +136,7 @@ func (i *indexer) packages() ([]*packages.Package, error) {
 }
 
 func (i *indexer) index(pkgs []*packages.Package) (*Stats, error) {
-	_, err := i.w.EmitMetaData("file://"+i.projectRoot, i.toolInfo)
+	_, err := i.w.EmitMetaData("file://"+i.repositoryRoot, i.toolInfo)
 	if err != nil {
 		return nil, fmt.Errorf(`emit "metadata": %v`, err)
 	}


### PR DESCRIPTION
This gives us a stable way to determine the repository-relative document URIs in the dump. Right now depending on the subdirectory you generate an LSIF dump in, we may not be able to resolve the paths from Sourcegraph's side.