### PR TITLE
Optimize hover text

### DIFF
--- a/internal/index/astutil.go
+++ b/internal/index/astutil.go
@@ -1,0 +1,129 @@
+package index
+
+import (
+	"go/ast"
+	"go/token"
+)
+
+// pathEnclosingInterval is a copy of the same function in the astutil
+// package modified to speed up indexing. These changes have reduced the
+// time necessary to process aws-sdk-go from 6m48s to 2m49s.
+//
+// Changes:
+//  - Modify the private helper childrenOf to not add bare (syntax)
+//    tokens to the output list. These don't do anything for us and
+//    adds time both in their addition and their iteration.
+func pathEnclosingInterval(root *ast.File, start, end token.Pos) (path []ast.Node, exact bool) {
+	// fmt.Printf("EnclosingInterval %d %d\n", start, end) // debugging
+
+	// Precondition: node.[Pos..End) and adjoining whitespace contain [start, end).
+	var visit func(node ast.Node) bool
+	visit = func(node ast.Node) bool {
+		path = append(path, node)
+
+		nodePos := node.Pos()
+		nodeEnd := node.End()
+
+		// fmt.Printf("visit(%T, %d, %d)\n", node, nodePos, nodeEnd) // debugging
+
+		// Intersect [start, end) with interval of node.
+		if start < nodePos {
+			start = nodePos
+		}
+		if end > nodeEnd {
+			end = nodeEnd
+		}
+
+		// Find sole child that contains [start, end).
+		children := childrenOf(node)
+		l := len(children)
+		for i, child := range children {
+			// [childPos, childEnd) is unaugmented interval of child.
+			childPos := child.Pos()
+			childEnd := child.End()
+
+			// [augPos, augEnd) is whitespace-augmented interval of child.
+			augPos := childPos
+			augEnd := childEnd
+			if i > 0 {
+				augPos = children[i-1].End() // start of preceding whitespace
+			}
+			if i < l-1 {
+				nextChildPos := children[i+1].Pos()
+				// Does [start, end) lie between child and next child?
+				if start >= augEnd && end <= nextChildPos {
+					return false // inexact match
+				}
+				augEnd = nextChildPos // end of following whitespace
+			}
+
+			// fmt.Printf("\tchild %d: [%d..%d)\tcontains interval [%d..%d)?\n",
+			// 	i, augPos, augEnd, start, end) // debugging
+
+			// Does augmented child strictly contain [start, end)?
+			if augPos <= start && end <= augEnd {
+				return visit(child)
+			}
+
+			// Does [start, end) overlap multiple children?
+			// i.e. left-augmented child contains start
+			// but LR-augmented child does not contain end.
+			if start < childEnd && end > augEnd {
+				break
+			}
+		}
+
+		// No single child contained [start, end),
+		// so node is the result.  Is it exact?
+
+		// (It's tempting to put this condition before the
+		// child loop, but it gives the wrong result in the
+		// case where a node (e.g. ExprStmt) and its sole
+		// child have equal intervals.)
+		if start == nodePos && end == nodeEnd {
+			return true // exact match
+		}
+
+		return false // inexact: overlaps multiple children
+	}
+
+	if start > end {
+		start, end = end, start
+	}
+
+	if start < root.End() && end > root.Pos() {
+		if start == end {
+			end = start + 1 // empty interval => interval of size 1
+		}
+		exact = visit(root)
+
+		// Reverse the path:
+		for i, l := 0, len(path); i < l/2; i++ {
+			path[i], path[l-1-i] = path[l-1-i], path[i]
+		}
+	} else {
+		// Selection lies within whitespace preceding the
+		// first (or following the last) declaration in the file.
+		// The result nonetheless always includes the ast.File.
+		path = append(path, root)
+	}
+
+	return
+}
+
+func childrenOf(n ast.Node) []ast.Node {
+	var children []ast.Node
+
+	ast.Inspect(n, func(node ast.Node) bool {
+		if node == n {
+			// recur
+			return true
+		}
+		if node != nil {
+			children = append(children, node)
+		}
+		return false
+	})
+
+	return children
+}

--- a/internal/index/astutil.go
+++ b/internal/index/astutil.go
@@ -14,8 +14,6 @@ import (
 //    tokens to the output list. These don't do anything for us and
 //    adds time both in their addition and their iteration.
 func pathEnclosingInterval(root *ast.File, start, end token.Pos) (path []ast.Node, exact bool) {
-	// fmt.Printf("EnclosingInterval %d %d\n", start, end) // debugging
-
 	// Precondition: node.[Pos..End) and adjoining whitespace contain [start, end).
 	var visit func(node ast.Node) bool
 	visit = func(node ast.Node) bool {
@@ -23,8 +21,6 @@ func pathEnclosingInterval(root *ast.File, start, end token.Pos) (path []ast.Nod
 
 		nodePos := node.Pos()
 		nodeEnd := node.End()
-
-		// fmt.Printf("visit(%T, %d, %d)\n", node, nodePos, nodeEnd) // debugging
 
 		// Intersect [start, end) with interval of node.
 		if start < nodePos {
@@ -56,9 +52,6 @@ func pathEnclosingInterval(root *ast.File, start, end token.Pos) (path []ast.Nod
 				}
 				augEnd = nextChildPos // end of following whitespace
 			}
-
-			// fmt.Printf("\tchild %d: [%d..%d)\tcontains interval [%d..%d)?\n",
-			// 	i, augPos, augEnd, start, end) // debugging
 
 			// Does augmented child strictly contain [start, end)?
 			if augPos <= start && end <= augEnd {

--- a/internal/index/helper.go
+++ b/internal/index/helper.go
@@ -10,7 +10,6 @@ import (
 
 	doc "github.com/slimsag/godocmd"
 	"github.com/sourcegraph/lsif-go/protocol"
-	"golang.org/x/tools/go/ast/astutil"
 	"golang.org/x/tools/go/packages"
 )
 
@@ -205,7 +204,7 @@ func findComments(pkgs []*packages.Package, p *packages.Package, f *ast.File, o 
 	}
 
 	// Resolve the object o into its respective ast.Node
-	paths, exact := astutil.PathEnclosingInterval(f, o.Pos(), o.Pos())
+	paths, exact := pathEnclosingInterval(f, o.Pos(), o.Pos())
 	if !exact {
 		return "", nil
 	}

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -354,6 +354,8 @@ func (i *indexer) addImports(p *packages.Package, f *ast.File, fi *fileInfo) err
 }
 
 func (i *indexer) indexDefs(pkgs []*packages.Package, p *packages.Package, f *ast.File, fi *fileInfo, proID, filename string) error {
+	fmt.Fprintf(os.Stdout, ".")
+
 	var rangeIDs []string
 	for ident, obj := range p.TypesInfo.Defs {
 		// Object is nil when not denote an object
@@ -485,6 +487,8 @@ func (i *indexer) indexDefs(pkgs []*packages.Package, p *packages.Package, f *as
 }
 
 func (i *indexer) indexUses(pkgs []*packages.Package, p *packages.Package, fi *fileInfo, filename string) error {
+	fmt.Fprintf(os.Stdout, ".")
+
 	var rangeIDs []string
 	for ident, obj := range p.TypesInfo.Uses {
 		// Only emit if the object belongs to current file


### PR DESCRIPTION
The overwhelming cost of indexing has been determined to be converting an AST position into an AST node. This requires multiple traversals down the AST. This PR speeds up indexing by inlining and optimizing `awsutil.PathEnclosingInterval`.