### PR TITLE
Add a flag to specify an alternate module root.

### DIFF
--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -105,9 +105,9 @@ func realMain() error {
 		Args:    os.Args[1:],
 	}
 
-	// TODO(@creachadair): Packages built with cgo may not include assembly
-	// files.  To index such a package you need to set CGO_ENABLED=0.  Consider
-	// maybe doing this explicitly, always.
+	// TODO(@creachadair): With cgo enabled, the indexer cannot handle packages
+	// that include assembly (.s) files.  To index such a package you need to
+	// set CGO_ENABLED=0.  Consider maybe doing this explicitly, always.
 	indexer := index.NewIndexer(
 		projectRoot,
 		repositoryRoot,

--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -17,7 +17,7 @@ import (
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 
-const version = "0.4.1"
+const version = "0.5.0"
 const versionString = version + ", protocol version " + protocol.Version
 
 func init() {

--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -106,7 +106,7 @@ func realMain() error {
 	}
 
 	// TODO(@creachadair): With cgo enabled, the indexer cannot handle packages
-	// that include assembly (.s) files.  To index such a package you need to
+	// that include assembly (.s) files. To index such a package you need to
 	// set CGO_ENABLED=0. Consider maybe doing this explicitly, always.
 	indexer := index.NewIndexer(
 		projectRoot,

--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -81,6 +81,11 @@ func realMain() error {
 		return errors.New("module root is outside the repository")
 	}
 
+	// Ensure all the dependencies of the specified module are cached.
+	if err := gomod.Download(projectRoot); err != nil {
+		return fmt.Errof("fetching dependencies: %v", err)
+	}
+
 	moduleName, dependencies, err := gomod.ListModules(projectRoot)
 	if err != nil {
 		return err

--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -107,7 +107,7 @@ func realMain() error {
 
 	// TODO(@creachadair): With cgo enabled, the indexer cannot handle packages
 	// that include assembly (.s) files.  To index such a package you need to
-	// set CGO_ENABLED=0.  Consider maybe doing this explicitly, always.
+	// set CGO_ENABLED=0. Consider maybe doing this explicitly, always.
 	indexer := index.NewIndexer(
 		projectRoot,
 		repositoryRoot,

--- a/internal/gomod/module.go
+++ b/internal/gomod/module.go
@@ -60,7 +60,7 @@ func ListModules(projectRoot string) (string, map[string]string, error) {
 		return "", nil, nil
 	}
 
-	out, err := run(projectRoot, "go", "list", "-m", "all")
+	out, err := run(projectRoot, "go", "list", "-mod=readonly", "-m", "all")
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to list modules: %v", err)
 	}

--- a/internal/gomod/module.go
+++ b/internal/gomod/module.go
@@ -81,6 +81,13 @@ func ListModules(projectRoot string) (string, map[string]string, error) {
 	return lines[0], dependencies, nil
 }
 
+// Download fetches all the dependencies of the module in projectRoot.
+func Download(projectRoot string) error {
+	cmd := exec.Command("go", "mod", "download")
+	cmd.Dir = projectRoot
+	return cmd.Run()
+}
+
 // versionPattern matches the form vX.Y.Z.-yyyymmddhhmmss-abcdefabcdef
 var versionPattern = regexp.MustCompile(`^(.*)-(\d{14})-([a-f0-9]{12})$`)
 


### PR DESCRIPTION
Although it is common practice, not all Go repositories have the go.mod file at
the repo root. Add a --moduleRoot flag that allows the caller to specify a path
relative to the repository root, that should be used as the module root for the
purpose of indexing.