### PR TITLE
Single-pass hover text extraction

### DIFF
--- a/internal/index/hoverloader.go
+++ b/internal/index/hoverloader.go
@@ -1,0 +1,122 @@
+package index
+
+import (
+	"go/ast"
+	"go/token"
+	"sort"
+	"sync"
+)
+
+type HoverLoader struct {
+	m     sync.RWMutex
+	cache map[*ast.File]map[token.Pos]string
+}
+
+// newHoverLoader creates a new empty HoverLoader.
+func newHoverLoader() *HoverLoader {
+	return &HoverLoader{
+		cache: map[*ast.File]map[token.Pos]string{},
+	}
+}
+
+// Load will walk the AST of the file and cache the hover text for each of the given positions.
+func (l *HoverLoader) Load(root *ast.File, positions []token.Pos) {
+	textMap := map[token.Pos]string{}
+	sort.Slice(positions, func(i, j int) bool { return positions[i] < positions[j] })
+	visit(root, positions, textMap, nil)
+
+	l.m.Lock()
+	l.cache[root] = textMap
+	l.m.Unlock()
+}
+
+// Text will return the hover text extracted from the given file. For non-empty hover text to be
+// returned from this method, Load must have been previously called with this file and position
+// as arguments.
+func (l *HoverLoader) Text(root *ast.File, position token.Pos) string {
+	l.m.RLock()
+	text := l.cache[root][position]
+	l.m.RUnlock()
+
+	return text
+}
+
+// visit walks the AST for a file and assigns hover text to each position. A position's hover text
+// is the comment associated with the deepest node that encloses the position. Each call to visit
+// is given the unique path of ancestors from the root to the parent of the node. This slice should
+// not be directly altered.
+func visit(node ast.Node, positions []token.Pos, textMap map[token.Pos]string, path []ast.Node) {
+	newPath := append(append([]ast.Node(nil), path...), node)
+
+	for _, child := range childrenOf(node) {
+		visit(child, positions, textMap, newPath)
+	}
+
+	for i := findFirstIntersectingIndex(node, positions); i < len(positions) && positions[i] <= node.End(); i++ {
+		if _, ok := textMap[positions[i]]; ok {
+			continue
+		}
+
+		textMap[positions[i]] = commentsFromPath(newPath)
+	}
+}
+
+// findFirstIntersectingIndex finds the first index in positions that is not less than the
+// node's starting position. If there is no such index, then the length of the array is
+// returned.
+func findFirstIntersectingIndex(node ast.Node, positions []token.Pos) int {
+	i := 0
+	for i < len(positions) && positions[i] < node.Pos() {
+		i = (i + 1) * 2
+	}
+
+	if i >= len(positions) {
+		i = len(positions)
+	}
+
+	for i > 0 && positions[i-1] >= node.Pos() {
+		i--
+	}
+
+	return i
+}
+
+// childrenOf returns the direct non-nil children of ast.Node n.
+func childrenOf(n ast.Node) (children []ast.Node) {
+	ast.Inspect(n, func(node ast.Node) bool {
+		if node == n {
+			return true
+		}
+		if node != nil {
+			children = append(children, node)
+		}
+		return false
+	})
+
+	return children
+}
+
+const MaxCommentDistance = 3
+
+// commentsFromPath searches the given node path backwards and returns the first comment
+// attached to o node that it finds. This will only look at the last MaxCommentDistance
+// nodes of the given path.
+func commentsFromPath(path []ast.Node) (comment string) {
+	for i := 0; i < len(path) && i < MaxCommentDistance && comment == ""; i++ {
+		switch v := path[len(path)-i-1].(type) {
+		case *ast.Field:
+			// Concat associated documentation with any inline comments
+			comment = joinCommentGroups(v.Doc, v.Comment)
+		case *ast.FuncDecl:
+			comment = v.Doc.Text()
+		case *ast.GenDecl:
+			comment = v.Doc.Text()
+		case *ast.TypeSpec:
+			comment = v.Doc.Text()
+		case *ast.ValueSpec:
+			comment = v.Doc.Text()
+		}
+	}
+
+	return comment
+}

--- a/internal/index/hoverloader_test.go
+++ b/internal/index/hoverloader_test.go
@@ -1,0 +1,47 @@
+package index
+
+import (
+	"go/token"
+	"testing"
+)
+
+const TestPositionSize = 100000
+
+func TestFindFirstIntersectingIndex(t *testing.T) {
+	positions := make([]token.Pos, 0, TestPositionSize)
+	for i := 0; i < TestPositionSize; i++ {
+		positions = append(positions, token.Pos(i+500))
+	}
+
+	// first
+	if idx := findFirstIntersectingIndex(&node{token.Pos(500)}, positions); idx != 0 {
+		t.Errorf("unexpected index. want=%d have=%d", 0, idx)
+	}
+
+	// middle
+	if idx := findFirstIntersectingIndex(&node{token.Pos(TestPositionSize/2 + 500)}, positions); idx != TestPositionSize/2 {
+		t.Errorf("unexpected index. want=%d have=%d", TestPositionSize/2, idx)
+	}
+
+	// last
+	if idx := findFirstIntersectingIndex(&node{token.Pos(TestPositionSize + 500 - 1)}, positions); idx != TestPositionSize-1 {
+		t.Errorf("unexpected index. want=%d have=%d", TestPositionSize-1, idx)
+	}
+
+	// before
+	if idx := findFirstIntersectingIndex(&node{token.Pos(100)}, positions); idx != 0 {
+		t.Errorf("unexpected index. want=%d have=%d", 0, idx)
+	}
+
+	// after
+	if idx := findFirstIntersectingIndex(&node{token.Pos(TestPositionSize * 2)}, positions); idx != TestPositionSize {
+		t.Errorf("unexpected index. want=%d have=%d", TestPositionSize, idx)
+	}
+}
+
+type node struct {
+	pos token.Pos
+}
+
+func (n *node) Pos() token.Pos { return n.pos }
+func (n *node) End() token.Pos { return n.pos }

--- a/internal/index/indexer.go
+++ b/internal/index/indexer.go
@@ -8,7 +8,9 @@ import (
 	"go/types"
 	"io"
 	"os"
+	"runtime"
 	"strings"
+	"sync"
 
 	"github.com/sourcegraph/lsif-go/protocol"
 	"golang.org/x/tools/go/packages"
@@ -35,8 +37,10 @@ type indexer struct {
 	repositoryRoot string
 	toolInfo       protocol.ToolInfo
 	w              *protocol.Writer
+	hoverLoader    *HoverLoader
 
 	// De-duplication
+	packagesImported map[string]bool
 	defsIndexed      map[string]bool
 	usesIndexed      map[string]bool
 	ranges           map[string]map[int]string // filename -> offset -> rangeID
@@ -78,8 +82,10 @@ func NewIndexer(
 		dependencies:   dependencies,
 		toolInfo:       toolInfo,
 		w:              protocol.NewWriter(w, addContents),
+		hoverLoader:    newHoverLoader(),
 
 		// Empty maps
+		packagesImported:      map[string]bool{},
 		defsIndexed:           map[string]bool{},
 		usesIndexed:           map[string]bool{},
 		ranges:                map[string]map[int]string{},
@@ -100,6 +106,7 @@ func NewIndexer(
 // and writing the LSIF equivalent to the output source that implements io.Writer.
 // It is caller's responsibility to close the output source if applicable.
 func (i *indexer) Index() (*Stats, error) {
+	fmt.Fprintf(os.Stdout, "Loading packages\n")
 	pkgs, err := i.packages()
 	if err != nil {
 		return nil, err
@@ -115,12 +122,6 @@ func (i *indexer) packages() ([]*packages.Package, error) {
 			packages.NeedTypes | packages.NeedSyntax | packages.NeedTypesInfo,
 		Dir:   i.projectRoot,
 		Tests: true,
-		Logf: func(format string, args ...interface{}) {
-			// Print progress while the packages are loading
-			// We don't need to log this information, though
-			// (it's incredibly verbose)
-			fmt.Fprintf(os.Stdout, ".")
-		},
 	}, "./...")
 	if err != nil {
 		return nil, fmt.Errorf("load packages: %v", err)
@@ -144,22 +145,84 @@ func (i *indexer) index(pkgs []*packages.Package) (*Stats, error) {
 		return nil, fmt.Errorf(`emit "begin": %v`, err)
 	}
 
+	fmt.Fprintf(os.Stdout, "Preparing documents\n")
 	for _, p := range pkgs {
+		fmt.Fprintf(os.Stdout, ".")
+
 		if err := i.indexPkgDocs(p, proID); err != nil {
 			return nil, fmt.Errorf("index package %q: %v", p.Name, err)
 		}
+
+		if err := i.addPkgImports(pkgs, p, proID); err != nil {
+			return nil, fmt.Errorf("add package imports %q: %v", p.Name, err)
+		}
+	}
+	fmt.Fprintf(os.Stdout, "\n")
+
+	allPackages := map[*packages.Package]struct{}{}
+	for _, p := range pkgs {
+		allPackages[p] = struct{}{}
+
+		for _, i := range p.Imports {
+			allPackages[i] = struct{}{}
+		}
+	}
+
+	n := runtime.GOMAXPROCS(0)
+	sema := make(chan struct{}, n)
+	for i := 0; i < n; i++ {
+		sema <- struct{}{}
+	}
+
+	var wg sync.WaitGroup
+
+	fmt.Fprintf(os.Stdout, "Preloading hover text\n")
+	for p := range allPackages {
+		wg.Add(1)
+
+		go func(p *packages.Package) {
+			defer wg.Done()
+			<-sema
+			defer func() { sema <- struct{}{} }()
+
+			for _, f := range p.Syntax {
+				positions := make([]token.Pos, 0, len(p.TypesInfo.Defs))
+				for _, obj := range p.TypesInfo.Defs {
+					if obj != nil {
+						positions = append(positions, obj.Pos())
+					}
+				}
+
+				i.hoverLoader.Load(f, positions)
+			}
+
+			fmt.Fprintf(os.Stdout, ".")
+		}(p)
+	}
+	wg.Wait()
+	fmt.Fprintf(os.Stdout, "\n")
+
+	fmt.Fprintf(os.Stdout, "Indexing definitions\n")
+	for _, p := range pkgs {
+		fmt.Fprintf(os.Stdout, ".")
 
 		if err := i.indexPkgDefs(pkgs, p, proID); err != nil {
 			return nil, fmt.Errorf("index package defs %q: %v", p.Name, err)
 		}
 	}
+	fmt.Fprintf(os.Stdout, "\n")
 
+	fmt.Fprintf(os.Stdout, "Indexing uses\n")
 	for _, p := range pkgs {
+		fmt.Fprintf(os.Stdout, ".")
+
 		if err := i.indexPkgUses(pkgs, p, proID); err != nil {
 			return nil, fmt.Errorf("index package uses %q: %v", p.Name, err)
 		}
 	}
+	fmt.Fprintf(os.Stdout, "\n")
 
+	fmt.Fprintf(os.Stdout, "Finalizing reference results\n")
 	for _, f := range i.files {
 		fmt.Fprintf(os.Stdout, ".")
 
@@ -209,6 +272,7 @@ func (i *indexer) index(pkgs []*packages.Package) (*Stats, error) {
 			}
 		}
 	}
+	fmt.Fprintf(os.Stdout, "\n")
 
 	// Close all documents. This must be done as a last step as we need
 	// to emit everything about a document before sending the end event.
@@ -273,6 +337,29 @@ func (i *indexer) indexPkgDocs(p *packages.Package, proID string) (err error) {
 	return nil
 }
 
+func (i *indexer) addPkgImports(pkgs []*packages.Package, p *packages.Package, proID string) (err error) {
+	for _, f := range p.Syntax {
+		fpos := p.Fset.Position(f.Package)
+		fi, ok := i.files[fpos.Filename]
+		if !ok {
+			// File skipped in the loop above
+			continue
+		}
+
+		if _, ok := i.packagesImported[fpos.Filename]; ok {
+			// Defs already imported
+			continue
+		}
+		i.packagesImported[fpos.Filename] = true
+
+		if err = i.addImports(p, f, fi); err != nil {
+			return fmt.Errorf("error indexing imports of %q: %v", p.PkgPath, err)
+		}
+	}
+
+	return nil
+}
+
 func (i *indexer) indexPkgDefs(pkgs []*packages.Package, p *packages.Package, proID string) (err error) {
 	for _, f := range p.Syntax {
 		fpos := p.Fset.Position(f.Package)
@@ -287,10 +374,6 @@ func (i *indexer) indexPkgDefs(pkgs []*packages.Package, p *packages.Package, pr
 			continue
 		}
 		i.defsIndexed[fpos.Filename] = true
-
-		if err = i.addImports(p, f, fi); err != nil {
-			return fmt.Errorf("error indexing imports of %q: %v", p.PkgPath, err)
-		}
 
 		if err = i.indexDefs(pkgs, p, f, fi, proID, fpos.Filename); err != nil {
 			return fmt.Errorf("error indexing definitions of %q: %v", p.PkgPath, err)
@@ -400,9 +483,6 @@ func (i *indexer) indexDefs(pkgs []*packages.Package, p *packages.Package, f *as
 			i.refs[rangeID] = refResult
 		}
 
-		if _, ok := refResult.defRangeIDs[fi.docID]; !ok {
-			refResult.defRangeIDs[fi.docID] = []string{}
-		}
 		refResult.defRangeIDs[fi.docID] = append(refResult.defRangeIDs[fi.docID], rangeID)
 
 		_, err = i.w.EmitNext(rangeID, refResult.resultSetID)
@@ -585,9 +665,6 @@ func (i *indexer) indexUses(pkgs []*packages.Package, p *packages.Package, f *as
 
 		refResult := i.refs[def.rangeID]
 		if refResult != nil {
-			if _, ok := refResult.refRangeIDs[fi.docID]; !ok {
-				refResult.refRangeIDs[fi.docID] = []string{}
-			}
 			refResult.refRangeIDs[fi.docID] = append(refResult.refRangeIDs[fi.docID], rangeID)
 		}
 	}
@@ -626,7 +703,7 @@ func (i *indexer) makeCachedHoverResult(pkgs []*packages.Package, p *packages.Pa
 // makeHoverResult create a hover result vertex and returns its ID. This method
 // should be called for each definition in the set of indexed files.
 func (i *indexer) makeHoverResult(pkgs []*packages.Package, p *packages.Package, f *ast.File, obj types.Object) (string, error) {
-	contents, err := findContents(pkgs, p, f, obj)
+	contents, err := findContents(pkgs, p, f, obj, i.hoverLoader)
 	if err != nil {
 		return "", fmt.Errorf("find contents: %v", err)
 	}
@@ -651,7 +728,7 @@ func (i *indexer) makeCachedExternalHoverResult(pkgs []*packages.Package, p *pac
 		return hoverResultID, nil
 	}
 
-	contents, err := externalHoverContents(pkgs, p, obj, pkg)
+	contents, err := externalHoverContents(pkgs, p, obj, pkg, i.hoverLoader)
 	if err != nil || contents == nil {
 		return "", err
 	}
@@ -714,7 +791,7 @@ func (i *indexer) emitExportMoniker(sourceID, identifier string) error {
 
 // addMonikers outputs a "gomod" moniker vertex, attaches the given package vertex
 // identifier to it, and attaches the new moniker to the source moniker vertex.
-func (i *indexer) addMonikers(kind string, identifier string, sourceID, packageID string) error {
+func (i *indexer) addMonikers(kind, identifier, sourceID, packageID string) error {
 	monikerID, err := i.w.EmitMoniker(kind, "gomod", identifier)
 	if err != nil {
 		return err


### PR DESCRIPTION
The current implemtnation of lsif-go contains a super-quadratic way of determining comments based on token positions. For each definition, we trace the AST from the root of the containing file through nodes that intersect the target position (via `astutil.PathEnclosingInterval`) then extract the comments by tracing the constructed ancestor path backwards.

This requires us to scan the same file from the root for every definition that exists in that file. **Much** of this work will be repeated and we'll end up tracing the same path multiple times to get to definitions with slightly different paths. [Tell me that's not a bad idea in a world containing files of this size](https://github.com/aws/aws-sdk-go/blob/master/service/ec2/api.go).

This change introduces a pre-warmed cache of hover text that is extracted by traversing the AST of each file _once_. We further speed up this process by walking GOMAXPROC files in parallel.

- Before this change, aws-sdk-go indexes in 7m11s.
- After this change, aws-sdk-go indexes in 2m9s.