### PR TITLE
Refactor emitter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101
 	github.com/google/go-cmp v0.5.1
+	github.com/json-iterator/go v1.1.10
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3

--- a/go.mod
+++ b/go.mod
@@ -6,16 +6,13 @@ require (
 	github.com/alecthomas/kingpin v2.2.6+incompatible
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
 	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101
 	github.com/google/go-cmp v0.5.1
 	github.com/json-iterator/go v1.1.10
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3
-	github.com/sourcegraph/lsif-go/testdata v0.0.0-20200804185623-bb090d50c787 // indirect
 	golang.org/x/tools v0.0.0-20200212150539-ea181f53ac56
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
 	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.2.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3 h1:sAARUcYbwxnebBeWHzKX2MeyXtzy25TEglCTz9BhueY=
 github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3/go.mod h1:AIBPxLCkKUFc2ZkjCXzs/Kk9OUhQLw/Zicdd0Rhqz2U=
-github.com/sourcegraph/lsif-go/testdata v0.0.0-20200804185623-bb090d50c787 h1:DsAsuryZ2cohinSATsS8mVlXtJBow7KOKEvUFJrqQAs=
-github.com/sourcegraph/lsif-go/testdata v0.0.0-20200804185623-bb090d50c787/go.mod h1:nhIb9rqlDWCb8yKzltYZQrnI8pmE2xBC/qH5KdPnVJc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=

--- a/go.sum
+++ b/go.sum
@@ -12,11 +12,18 @@ github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101 h1:RylpU+KNJJNEJ
 github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101/go.mod h1:5ALWO82UZwfAtNRUtwzsWimcrcuYzyieTyyXOXrP6EQ=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -26,6 +33,7 @@ github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3/go.mod h1:AIBPxLCk
 github.com/sourcegraph/lsif-go/testdata v0.0.0-20200804185623-bb090d50c787 h1:DsAsuryZ2cohinSATsS8mVlXtJBow7KOKEvUFJrqQAs=
 github.com/sourcegraph/lsif-go/testdata v0.0.0-20200804185623-bb090d50c787/go.mod h1:nhIb9rqlDWCb8yKzltYZQrnI8pmE2xBC/qH5KdPnVJc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -180,9 +180,8 @@ type capturingWriter struct {
 	elements []interface{}
 }
 
-func (w *capturingWriter) Write(v interface{}) error {
+func (w *capturingWriter) Write(v interface{}) {
 	w.elements = append(w.elements, v)
-	return nil
 }
 
 func (w *capturingWriter) Flush() error {

--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -185,6 +185,10 @@ func (w *capturingWriter) Write(v interface{}) error {
 	return nil
 }
 
+func (w *capturingWriter) Flush() error {
+	return nil
+}
+
 // findDocumentURIByDocumentID returns the URI of the document with the given ID.
 func findDocumentURIByDocumentID(elements []interface{}, id string) string {
 	for _, elem := range elements {

--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -190,7 +190,7 @@ func (w *capturingWriter) Flush() error {
 }
 
 // findDocumentURIByDocumentID returns the URI of the document with the given ID.
-func findDocumentURIByDocumentID(elements []interface{}, id string) string {
+func findDocumentURIByDocumentID(elements []interface{}, id uint64) string {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Document:
@@ -204,7 +204,7 @@ func findDocumentURIByDocumentID(elements []interface{}, id string) string {
 }
 
 // findRangeByID returns the range with the given identifier.
-func findRangeByID(elements []interface{}, id string) *protocol.Range {
+func findRangeByID(elements []interface{}, id uint64) *protocol.Range {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Range:
@@ -218,7 +218,7 @@ func findRangeByID(elements []interface{}, id string) *protocol.Range {
 }
 
 // findHoverResultByID returns the hover result object with the given identifier.
-func findHoverResultByID(elements []interface{}, id string) *protocol.HoverResult {
+func findHoverResultByID(elements []interface{}, id uint64) *protocol.HoverResult {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.HoverResult:
@@ -232,7 +232,7 @@ func findHoverResultByID(elements []interface{}, id string) *protocol.HoverResul
 }
 
 // findMonikerByID returns the moniker with the given identifier.
-func findMonikerByID(elements []interface{}, id string) *protocol.Moniker {
+func findMonikerByID(elements []interface{}, id uint64) *protocol.Moniker {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Moniker:
@@ -246,7 +246,7 @@ func findMonikerByID(elements []interface{}, id string) *protocol.Moniker {
 }
 
 // findPackageInformationByID returns the moniker with the given identifier.
-func findPackageInformationByID(elements []interface{}, id string) *protocol.PackageInformation {
+func findPackageInformationByID(elements []interface{}, id uint64) *protocol.PackageInformation {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.PackageInformation:
@@ -261,7 +261,7 @@ func findPackageInformationByID(elements []interface{}, id string) *protocol.Pac
 
 // findDefintionRangesByDefinitionResultID returns the ranges attached to the definition result with the given
 // identifier.
-func findDefintionRangesByDefinitionResultID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findDefintionRangesByDefinitionResultID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Item:
@@ -280,7 +280,7 @@ func findDefintionRangesByDefinitionResultID(elements []interface{}, id string) 
 
 // findReferenceRangesByReferenceResultID returns the ranges attached to the reference result with the given
 // identifier.
-func findReferenceRangesByReferenceResultID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findReferenceRangesByReferenceResultID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Item:
@@ -298,7 +298,7 @@ func findReferenceRangesByReferenceResultID(elements []interface{}, id string) (
 }
 
 // findDocumentURIContaining finds the URI of the document containing the given ID.
-func findDocumentURIContaining(elements []interface{}, id string) string {
+func findDocumentURIContaining(elements []interface{}, id uint64) string {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Contains:
@@ -331,7 +331,7 @@ func findRange(elements []interface{}, filename string, startLine, startCharacte
 
 // findHoverResultByRangeOrResultSetID returns the hover result attached to the range or result
 // set with the given identifier.
-func findHoverResultByRangeOrResultSetID(elements []interface{}, id string) *protocol.HoverResult {
+func findHoverResultByRangeOrResultSetID(elements []interface{}, id uint64) *protocol.HoverResult {
 	// First see if we're attached to a hover result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -359,7 +359,7 @@ func findHoverResultByRangeOrResultSetID(elements []interface{}, id string) *pro
 
 // findDefinitionRangesByRangeOrResultSetID returns the definition ranges attached to the range or result set
 // with the given identifier.
-func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	// First see if we're attached to definition result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -385,7 +385,7 @@ func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id string)
 
 // findReferenceRangesByRangeOrResultSetID returns the reference ranges attached to the range or result set with
 // the given identifier.
-func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	// First see if we're attached to reference result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -411,7 +411,7 @@ func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id string) 
 
 // findMonikersByRangeOrReferenceResultID returns the monikers attached to the range or  reference result
 // with the given identifier.
-func findMonikersByRangeOrReferenceResultID(elements []interface{}, id string) (monikers []*protocol.Moniker) {
+func findMonikersByRangeOrReferenceResultID(elements []interface{}, id uint64) (monikers []*protocol.Moniker) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.MonikerEdge:
@@ -437,7 +437,7 @@ func findMonikersByRangeOrReferenceResultID(elements []interface{}, id string) (
 }
 
 // findPackageInformationByMonikerID returns the package information vertexes attached to the moniker with the given identifier.
-func findPackageInformationByMonikerID(elements []interface{}, id string) (packageInformation []*protocol.PackageInformation) {
+func findPackageInformationByMonikerID(elements []interface{}, id uint64) (packageInformation []*protocol.PackageInformation) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.PackageInformationEdge:

--- a/internal/indexer/hover.go
+++ b/internal/indexer/hover.go
@@ -28,13 +28,13 @@ func findExternalHoverContents(hoverLoader *HoverLoader, pkgs []*packages.Packag
 // makeCachedHoverResult returns a hover result vertex identifier. If hover text for the given
 // identifier has not already been emitted, a new vertex is created. Identifiers will share the
 // same hover result if they refer to the same identifier in the same target package.
-func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) (_ string, err error) {
+func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) (_ uint64, err error) {
 	key := makeCacheKey(pkg, obj)
 
 	hoverResultID, ok := i.hoverResultCache[key]
 	if !ok {
 		if hoverResultID, err = i.emitter.EmitHoverResult(fn()); err != nil {
-			return "", errors.Wrap(err, "writer.EmitHoverResult")
+			return 0, errors.Wrap(err, "writer.EmitHoverResult")
 		}
 
 		if key != "" {

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -185,7 +185,7 @@ func (i *Indexer) emitDocument(f FileInfo) error {
 		return errors.Wrap(err, "writer.EmitDocument")
 	}
 
-	// TODO - this should be done at the end
+	// TODO(efritz) - we should collapse this
 	if _, err := i.emitter.EmitContains(i.projectID, []uint64{documentID}); err != nil {
 		return errors.Wrap(err, "writer.EmitContains")
 	}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -33,13 +33,13 @@ type Indexer struct {
 
 	// LSIF data cache
 	documents             map[string]*DocumentInfo        // filename -> info
-	ranges                map[string]map[int]string       // filename -> offset -> rangeID
-	hoverResultCache      map[string]string               // cache key -> hoverResultID
-	referenceResults      map[string]*ReferenceResultInfo // rangeID -> info
-	packageInformationIDs map[string]string               // name -> packageInformationID
+	ranges                map[string]map[int]uint64       // filename -> offset -> rangeID
+	hoverResultCache      map[string]uint64               // cache key -> hoverResultID
+	referenceResults      map[uint64]*ReferenceResultInfo // rangeID -> info
+	packageInformationIDs map[string]uint64               // name -> packageInformationID
 	hoverLoader           *HoverLoader                    // hover text cache
 	packages              []*packages.Package             // index target packages
-	projectID             string                          // project vertex identifier
+	projectID             uint64                          // project vertex identifier
 }
 
 func New(
@@ -68,10 +68,10 @@ func New(
 		types:                 map[string]*DefinitionInfo{},
 		vars:                  map[token.Pos]*DefinitionInfo{},
 		documents:             map[string]*DocumentInfo{},
-		ranges:                map[string]map[int]string{},
-		hoverResultCache:      map[string]string{},
-		referenceResults:      map[string]*ReferenceResultInfo{},
-		packageInformationIDs: map[string]string{},
+		ranges:                map[string]map[int]uint64{},
+		hoverResultCache:      map[string]uint64{},
+		referenceResults:      map[uint64]*ReferenceResultInfo{},
+		packageInformationIDs: map[string]uint64{},
 		hoverLoader:           newHoverLoader(),
 	}
 }
@@ -185,12 +185,13 @@ func (i *Indexer) emitDocument(f FileInfo) error {
 		return errors.Wrap(err, "writer.EmitDocument")
 	}
 
-	if _, err := i.emitter.EmitContains(i.projectID, []string{documentID}); err != nil {
+	// TODO - this should be done at the end
+	if _, err := i.emitter.EmitContains(i.projectID, []uint64{documentID}); err != nil {
 		return errors.Wrap(err, "writer.EmitContains")
 	}
 
 	i.documents[f.Filename] = &DocumentInfo{DocumentID: documentID}
-	i.ranges[f.Filename] = map[int]string{}
+	i.ranges[f.Filename] = map[int]uint64{}
 	return nil
 }
 
@@ -287,7 +288,7 @@ func (i *Indexer) indexDefinitions() error {
 
 // indexDefinitions emits data for each definition within the given document.
 func (i *Indexer) indexDefinitionsForFile(f FileInfo) error {
-	var rangeIDs []string
+	var rangeIDs []uint64
 	for ident, obj := range f.Package.TypesInfo.Defs {
 		ipos := f.Package.Fset.Position(ident.Pos())
 
@@ -319,20 +320,20 @@ func (i *Indexer) indexDefinitionsForFile(f FileInfo) error {
 }
 
 // indexDefinition emits data for the given definition object.
-func (i *Indexer) indexDefinition(o ObjectInfo) (string, error) {
+func (i *Indexer) indexDefinition(o ObjectInfo) (uint64, error) {
 	rangeID, err := i.emitter.EmitRange(rangeForObject(o))
 	if err != nil {
-		return "", errors.Wrap(err, "writer.EmitRange")
+		return 0, errors.Wrap(err, "writer.EmitRange")
 	}
 
 	resultSetID, err := i.emitter.EmitResultSet()
 	if err != nil {
-		return "", errors.Wrap(err, "writer.EmitResultSet")
+		return 0, errors.Wrap(err, "writer.EmitResultSet")
 	}
 
 	defResultID, err := i.emitter.EmitDefinitionResult()
 	if err != nil {
-		return "", errors.Wrap(err, "writer.EmitDefinitionResult")
+		return 0, errors.Wrap(err, "writer.EmitDefinitionResult")
 	}
 
 	// Create a hover result vertex and cache the result identifier keyed by the definition location.
@@ -342,40 +343,40 @@ func (i *Indexer) indexDefinition(o ObjectInfo) (string, error) {
 		return findHoverContents(i.hoverLoader, i.packages, o)
 	})
 	if err != nil {
-		return "", errors.Wrap(err, "findContents")
+		return 0, errors.Wrap(err, "findContents")
 	}
 
 	// Link range -> result set
 	if _, err := i.emitter.EmitNext(rangeID, resultSetID); err != nil {
-		return "", errors.Wrap(err, "writer.EmitNext")
+		return 0, errors.Wrap(err, "writer.EmitNext")
 	}
 
 	// Link result set -> definition result
 	if _, err := i.emitter.EmitTextDocumentDefinition(resultSetID, defResultID); err != nil {
-		return "", errors.Wrap(err, "writer.EmitTextDocumentDefinition")
+		return 0, errors.Wrap(err, "writer.EmitTextDocumentDefinition")
 	}
 
 	// Link definition result -> range
-	if _, err := i.emitter.EmitItem(defResultID, []string{rangeID}, o.FileInfo.Document.DocumentID); err != nil {
-		return "", errors.Wrap(err, "writer.EmitItem")
+	if _, err := i.emitter.EmitItem(defResultID, []uint64{rangeID}, o.FileInfo.Document.DocumentID); err != nil {
+		return 0, errors.Wrap(err, "writer.EmitItem")
 	}
 
 	// Link result set -> hover result
 	if _, err := i.emitter.EmitTextDocumentHover(resultSetID, hoverResultID); err != nil {
-		return "", errors.Wrap(err, "writer.EmitTextDocumentHover")
+		return 0, errors.Wrap(err, "writer.EmitTextDocumentHover")
 	}
 
 	if _, ok := o.Object.(*types.PkgName); ok {
 		// Emit import moniker attached to result set
 		if err := i.emitImportMoniker(resultSetID, o); err != nil {
-			return "", errors.Wrap(err, "emitImportMoniker")
+			return 0, errors.Wrap(err, "emitImportMoniker")
 		}
 	}
 
 	if o.Ident.IsExported() {
 		// Emit export moniker attached to result set
 		if err := i.emitExportMoniker(resultSetID, o); err != nil {
-			return "", errors.Wrap(err, "emitExportMoniker")
+			return 0, errors.Wrap(err, "emitExportMoniker")
 		}
 	}
 
@@ -387,8 +388,8 @@ func (i *Indexer) indexDefinition(o ObjectInfo) (string, error) {
 
 	i.referenceResults[rangeID] = &ReferenceResultInfo{
 		ResultSetID:        resultSetID,
-		DefinitionRangeIDs: map[string][]string{o.FileInfo.Document.DocumentID: {rangeID}},
-		ReferenceRangeIDs:  map[string][]string{},
+		DefinitionRangeIDs: map[uint64][]uint64{o.FileInfo.Document.DocumentID: {rangeID}},
+		ReferenceRangeIDs:  map[uint64][]uint64{},
 	}
 
 	i.ranges[o.Filename][o.Position.Offset] = rangeID
@@ -425,7 +426,7 @@ func (i *Indexer) indexReferences() error {
 
 // indexReferencesForFile emits data for each reference within the given document.
 func (i *Indexer) indexReferencesForFile(f FileInfo) error {
-	var rangeIDs []string
+	var rangeIDs []uint64
 	for ident, obj := range f.Package.TypesInfo.Uses {
 		ipos := f.Package.Fset.Position(ident.Pos())
 
@@ -455,7 +456,7 @@ func (i *Indexer) indexReferencesForFile(f FileInfo) error {
 }
 
 // indexReference emits data for the given reference object.
-func (i *Indexer) indexReference(o ObjectInfo) (string, bool, error) {
+func (i *Indexer) indexReference(o ObjectInfo) (uint64, bool, error) {
 	if def := i.getDefinitionInfo(o.Object); def != nil {
 		return i.indexReferenceToDefinition(o, def)
 	}
@@ -487,15 +488,15 @@ func (i *Indexer) getDefinitionInfo(obj types.Object) *DefinitionInfo {
 
 // indexReferenceToDefinition emits data for the given reference object that is defined within
 // an index target package.
-func (i *Indexer) indexReferenceToDefinition(o ObjectInfo, d *DefinitionInfo) (string, bool, error) {
+func (i *Indexer) indexReferenceToDefinition(o ObjectInfo, d *DefinitionInfo) (uint64, bool, error) {
 	rangeID, err := i.ensureRangeFor(o)
 	if err != nil {
-		return "", false, errors.Wrap(err, "ensureRangeFor")
+		return 0, false, errors.Wrap(err, "ensureRangeFor")
 	}
 
 	// Link range -> result set
 	if _, err := i.emitter.EmitNext(rangeID, d.ResultSetID); err != nil {
-		return "", false, errors.Wrap(err, "writer.EmitNext")
+		return 0, false, errors.Wrap(err, "writer.EmitNext")
 	}
 
 	if refResult := i.referenceResults[d.RangeID]; refResult != nil {
@@ -508,20 +509,20 @@ func (i *Indexer) indexReferenceToDefinition(o ObjectInfo, d *DefinitionInfo) (s
 // indexReferenceToExternalDefinition emits data for the given reference object that is not defined
 // within an index target package. This definition _may_ be resolvable by scanning dependencies, but
 // it is not guaranteed.
-func (i *Indexer) indexReferenceToExternalDefinition(o ObjectInfo) (string, bool, error) {
+func (i *Indexer) indexReferenceToExternalDefinition(o ObjectInfo) (uint64, bool, error) {
 	definitionPkg := o.Object.Pkg()
 	if definitionPkg == nil {
-		return "", false, nil
+		return 0, false, nil
 	}
 
 	rangeID, err := i.ensureRangeFor(o)
 	if err != nil {
-		return "", false, errors.Wrap(err, "ensureRangeFor")
+		return 0, false, errors.Wrap(err, "ensureRangeFor")
 	}
 
 	refResultID, err := i.emitter.EmitReferenceResult()
 	if err != nil {
-		return "", false, errors.Wrap(err, "writer.EmitReferenceResult")
+		return 0, false, errors.Wrap(err, "writer.EmitReferenceResult")
 	}
 
 	// Create a or retreive a hover result identifier keyed by the target object's identifier
@@ -532,29 +533,29 @@ func (i *Indexer) indexReferenceToExternalDefinition(o ObjectInfo) (string, bool
 		return findExternalHoverContents(i.hoverLoader, i.packages, o)
 	})
 	if err != nil {
-		return "", false, errors.Wrap(err, "externalHoverContents")
+		return 0, false, errors.Wrap(err, "externalHoverContents")
 	}
 
 	// Link range -> reference result
 	if _, err := i.emitter.EmitTextDocumentReferences(rangeID, refResultID); err != nil {
-		return "", false, errors.Wrap(err, "writer.EmitTextDocumentReferences")
+		return 0, false, errors.Wrap(err, "writer.EmitTextDocumentReferences")
 	}
 
 	// Link reference result -> range
-	if _, err := i.emitter.EmitItemOfReferences(refResultID, []string{rangeID}, o.FileInfo.Document.DocumentID); err != nil {
-		return "", false, errors.Wrap(err, "writer.EmitItemOfReferences")
+	if _, err := i.emitter.EmitItemOfReferences(refResultID, []uint64{rangeID}, o.FileInfo.Document.DocumentID); err != nil {
+		return 0, false, errors.Wrap(err, "writer.EmitItemOfReferences")
 	}
 
-	if hoverResultID != "" {
+	if hoverResultID != 0 {
 		// Link range -> hover result
 		if _, err := i.emitter.EmitTextDocumentHover(rangeID, hoverResultID); err != nil {
-			return "", false, errors.Wrap(err, "writer.EmitTextDocumentHover")
+			return 0, false, errors.Wrap(err, "writer.EmitTextDocumentHover")
 		}
 	}
 
 	// Emit import moniker attached to result set
 	if err := i.emitImportMoniker(rangeID, o); err != nil {
-		return "", false, errors.Wrap(err, "emitImportMoniker")
+		return 0, false, errors.Wrap(err, "emitImportMoniker")
 	}
 
 	return rangeID, true, nil
@@ -562,11 +563,11 @@ func (i *Indexer) indexReferenceToExternalDefinition(o ObjectInfo) (string, bool
 
 // ensureRangeFor returns a range identifier for the given object. If a range for the object has
 // not been emitted, a new vertex is created.
-func (i *Indexer) ensureRangeFor(o ObjectInfo) (_ string, err error) {
+func (i *Indexer) ensureRangeFor(o ObjectInfo) (_ uint64, err error) {
 	rangeID, ok := i.ranges[o.Filename][o.Position.Offset]
 	if !ok {
 		if rangeID, err = i.emitter.EmitRange(rangeForObject(o)); err != nil {
-			return "", errors.Wrap(err, "writer.EmitRange")
+			return 0, errors.Wrap(err, "writer.EmitRange")
 		}
 		i.ranges[o.Filename][o.Position.Offset] = rangeID
 	}
@@ -640,9 +641,9 @@ func (i *Indexer) emitContainsForFile(f FileInfo) error {
 // stats returns a Stats object with the number of packages, files, and elements analyzed/emitted.
 func (i *Indexer) stats() *Stats {
 	return &Stats{
-		NumPkgs:     len(i.packages),
-		NumFiles:    len(i.documents),
-		NumDefs:     len(i.consts) + len(i.funcs) + len(i.imports) + len(i.labels) + len(i.types) + len(i.vars),
+		NumPkgs:     uint(len(i.packages)),
+		NumFiles:    uint(len(i.documents)),
+		NumDefs:     uint(len(i.consts) + len(i.funcs) + len(i.imports) + len(i.labels) + len(i.types) + len(i.vars)),
 		NumElements: i.emitter.NumElements(),
 	}
 }

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sourcegraph/lsif-go/internal/writer"
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 
@@ -19,7 +18,7 @@ func TestIndexer(t *testing.T) {
 		"testdata",
 		"0.0.1",
 		nil,
-		writer.NewEmitter(w),
+		w,
 		false,
 	)
 

--- a/internal/indexer/info.go
+++ b/internal/indexer/info.go
@@ -10,10 +10,10 @@ import (
 
 // Stats summarizes the amount of work done by the indexer.
 type Stats struct {
-	NumPkgs     int
-	NumFiles    int
-	NumDefs     int
-	NumElements int
+	NumPkgs     uint
+	NumFiles    uint
+	NumDefs     uint
+	NumElements uint64
 }
 
 // FileInfo provides context about a particular file.
@@ -27,9 +27,9 @@ type FileInfo struct {
 // DocumentInfo provides context for constructing the contains relationship between
 // a document and the ranges that it contains.
 type DocumentInfo struct {
-	DocumentID         string
-	DefinitionRangeIDs []string
-	ReferenceRangeIDs  []string
+	DocumentID         uint64
+	DefinitionRangeIDs []uint64
+	ReferenceRangeIDs  []uint64
 }
 
 // ObjectInfo provides context about a particular object within a file.
@@ -44,15 +44,15 @@ type ObjectInfo struct {
 // of this shape is keyed by type and identifier in the indexer so that it can be
 // re-retrieved for a range that uses the definition.
 type DefinitionInfo struct {
-	DocumentID  string
-	RangeID     string
-	ResultSetID string
+	DocumentID  uint64
+	RangeID     uint64
+	ResultSetID uint64
 }
 
 // ReferenceResultInfo provides context about a definition range. Each definition and
 // reference range will be added to an object of this shape as it is processed.
 type ReferenceResultInfo struct {
-	ResultSetID        string
-	DefinitionRangeIDs map[string][]string
-	ReferenceRangeIDs  map[string][]string
+	ResultSetID        uint64
+	DefinitionRangeIDs map[uint64][]uint64
+	ReferenceRangeIDs  map[uint64][]uint64
 }

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -13,7 +13,7 @@ import (
 // emitExportMoniker emits an export moniker for the given object linked to the given source
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the current module.
-func (i *Indexer) emitExportMoniker(sourceID string, o ObjectInfo) error {
+func (i *Indexer) emitExportMoniker(sourceID uint64, o ObjectInfo) error {
 	if i.moduleName == "" {
 		// Unknown dependencies, skip export monikers
 		return nil
@@ -31,7 +31,7 @@ func (i *Indexer) emitExportMoniker(sourceID string, o ObjectInfo) error {
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the dependency containing
 // the identifier.
-func (i *Indexer) emitImportMoniker(sourceID string, o ObjectInfo) error {
+func (i *Indexer) emitImportMoniker(sourceID uint64, o ObjectInfo) error {
 	pkg := monikerPackage(o)
 
 	for _, moduleName := range packagePrefixes(pkg) {
@@ -67,11 +67,11 @@ func packagePrefixes(packageName string) []string {
 // ensurePackageInformation returns the identifier of a package information vertex with the
 // give name and version. A vertex will be emitted only if one with the same name not yet
 // been emitted.
-func (i *Indexer) ensurePackageInformation(name, version string) (_ string, err error) {
+func (i *Indexer) ensurePackageInformation(name, version string) (_ uint64, err error) {
 	packageInformationID, ok := i.packageInformationIDs[name]
 	if !ok {
 		if packageInformationID, err = i.emitter.EmitPackageInformation(name, "gomod", version); err != nil {
-			return "", errors.Wrap(err, "writer.EmitPackageInformation")
+			return 0, errors.Wrap(err, "writer.EmitPackageInformation")
 		}
 
 		i.packageInformationIDs[name] = packageInformationID
@@ -83,7 +83,7 @@ func (i *Indexer) ensurePackageInformation(name, version string) (_ string, err 
 // addMonikers emits a moniker vertex with the given identifier, an edge from the moniker
 // to the given package information vertex identifier, and an edge from the given source
 // identifier to the moniker vertex identifier.
-func (i *Indexer) addMonikers(kind, identifier, sourceID, packageID string) error {
+func (i *Indexer) addMonikers(kind, identifier string, sourceID, packageID uint64) error {
 	monikerID, err := i.emitter.EmitMoniker(kind, "gomod", identifier)
 	if err != nil {
 		return errors.Wrap(err, "writer.EmitMoniker")

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -6,49 +6,45 @@ import (
 	"go/types"
 	"strings"
 
-	"github.com/pkg/errors"
 	"golang.org/x/tools/go/ast/astutil"
 )
 
 // emitExportMoniker emits an export moniker for the given object linked to the given source
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the current module.
-func (i *Indexer) emitExportMoniker(sourceID uint64, o ObjectInfo) error {
+func (i *Indexer) emitExportMoniker(sourceID uint64, o ObjectInfo) {
 	if i.moduleName == "" {
 		// Unknown dependencies, skip export monikers
-		return nil
+		return
 	}
 
-	packageInformationID, err := i.ensurePackageInformation(i.moduleName, i.moduleVersion)
-	if err != nil {
-		return errors.Wrap(err, "ensurePackageInformation")
-	}
-
-	return i.addMonikers("export", strings.Trim(fmt.Sprintf("%s:%s", monikerPackage(o), monikerIdentifier(o)), ":"), sourceID, packageInformationID)
+	i.addMonikers(
+		"export",
+		strings.Trim(fmt.Sprintf("%s:%s", monikerPackage(o), monikerIdentifier(o)), ":"),
+		sourceID,
+		i.ensurePackageInformation(i.moduleName, i.moduleVersion),
+	)
 }
 
 // emitImportMoniker emits an import moniker for the given object linked to the given source
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the dependency containing
 // the identifier.
-func (i *Indexer) emitImportMoniker(sourceID uint64, o ObjectInfo) error {
+func (i *Indexer) emitImportMoniker(sourceID uint64, o ObjectInfo) {
 	pkg := monikerPackage(o)
 
 	for _, moduleName := range packagePrefixes(pkg) {
-		moduleVersion, ok := i.dependencies[moduleName]
-		if !ok {
-			continue
-		}
+		if moduleVersion, ok := i.dependencies[moduleName]; ok {
+			i.addMonikers(
+				"import",
+				strings.Trim(fmt.Sprintf("%s:%s", pkg, monikerIdentifier(o)), ":"),
+				sourceID,
+				i.ensurePackageInformation(moduleName, moduleVersion),
+			)
 
-		packageInformationID, err := i.ensurePackageInformation(moduleName, moduleVersion)
-		if err != nil {
-			return errors.Wrap(err, "ensurePackageInformation")
+			break
 		}
-
-		return i.addMonikers("import", strings.Trim(fmt.Sprintf("%s:%s", pkg, monikerIdentifier(o)), ":"), sourceID, packageInformationID)
 	}
-
-	return nil
 }
 
 // packagePrefixes return sall prefix of the go package path. For example, the package
@@ -67,37 +63,23 @@ func packagePrefixes(packageName string) []string {
 // ensurePackageInformation returns the identifier of a package information vertex with the
 // give name and version. A vertex will be emitted only if one with the same name not yet
 // been emitted.
-func (i *Indexer) ensurePackageInformation(name, version string) (_ uint64, err error) {
-	packageInformationID, ok := i.packageInformationIDs[name]
-	if !ok {
-		if packageInformationID, err = i.emitter.EmitPackageInformation(name, "gomod", version); err != nil {
-			return 0, errors.Wrap(err, "writer.EmitPackageInformation")
-		}
-
-		i.packageInformationIDs[name] = packageInformationID
+func (i *Indexer) ensurePackageInformation(name, version string) uint64 {
+	if packageInformationID, ok := i.packageInformationIDs[name]; ok {
+		return packageInformationID
 	}
 
-	return packageInformationID, nil
+	packageInformationID := i.emitter.EmitPackageInformation(name, "gomod", version)
+	i.packageInformationIDs[name] = packageInformationID
+	return packageInformationID
 }
 
 // addMonikers emits a moniker vertex with the given identifier, an edge from the moniker
 // to the given package information vertex identifier, and an edge from the given source
 // identifier to the moniker vertex identifier.
-func (i *Indexer) addMonikers(kind, identifier string, sourceID, packageID uint64) error {
-	monikerID, err := i.emitter.EmitMoniker(kind, "gomod", identifier)
-	if err != nil {
-		return errors.Wrap(err, "writer.EmitMoniker")
-	}
-
-	if _, err := i.emitter.EmitPackageInformationEdge(monikerID, packageID); err != nil {
-		return errors.Wrap(err, "writer.EmitPackageInformationEdge")
-	}
-
-	if _, err := i.emitter.EmitMonikerEdge(sourceID, monikerID); err != nil {
-		return errors.Wrap(err, "writer.EmitMonikerEdge")
-	}
-
-	return nil
+func (i *Indexer) addMonikers(kind, identifier string, sourceID, packageID uint64) {
+	monikerID := i.emitter.EmitMoniker(kind, "gomod", identifier)
+	_ = i.emitter.EmitPackageInformationEdge(monikerID, packageID)
+	_ = i.emitter.EmitMonikerEdge(sourceID, monikerID)
 }
 
 // monikerPackage returns the package prefix used to construct a unique moniker for the given object.

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -29,12 +29,10 @@ func TestEmitExportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitExportMoniker(123, ObjectInfo{
+	indexer.emitExportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
-	}); err != nil {
-		t.Fatalf("unexpected error emitting moniker: %s", err)
-	}
+	})
 
 	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
@@ -81,12 +79,10 @@ func TestEmitImportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitImportMoniker(123, ObjectInfo{
+	indexer.emitImportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
-	}); err != nil {
-		t.Fatalf("unexpected error emitting moniker: %s", err)
-	}
+	})
 
 	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -18,7 +18,7 @@ func TestEmitExportMoniker(t *testing.T) {
 		moduleName:            "github.com/sourcegraph/lsif-go",
 		moduleVersion:         "3.14.159",
 		emitter:               writer.NewEmitter(w),
-		packageInformationIDs: map[string]string{},
+		packageInformationIDs: map[string]uint64{},
 	}
 
 	object := types.NewConst(
@@ -29,14 +29,14 @@ func TestEmitExportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitExportMoniker("123", ObjectInfo{
+	if err := indexer.emitExportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
 	}); err != nil {
 		t.Fatalf("unexpected error emitting moniker: %s", err)
 	}
 
-	monikers := findMonikersByRangeOrReferenceResultID(w.elements, "123")
+	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
 		t.Fatalf("could not find moniker")
 	}
@@ -70,7 +70,7 @@ func TestEmitImportMoniker(t *testing.T) {
 			"github.com/test/pkg/sub1": "1.2.3-deadbeef",
 		},
 		emitter:               writer.NewEmitter(w),
-		packageInformationIDs: map[string]string{},
+		packageInformationIDs: map[string]uint64{},
 	}
 
 	object := types.NewConst(
@@ -81,14 +81,14 @@ func TestEmitImportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitImportMoniker("123", ObjectInfo{
+	if err := indexer.emitImportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
 	}); err != nil {
 		t.Fatalf("unexpected error emitting moniker: %s", err)
 	}
 
-	monikers := findMonikersByRangeOrReferenceResultID(w.elements, "123")
+	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
 		t.Fatalf("could not find moniker")
 	}

--- a/internal/indexer/util.go
+++ b/internal/indexer/util.go
@@ -1,8 +1,8 @@
 package indexer
 
-// union concatenates, flattens, and deduplicates the given string slices.
-func union(as ...[]string) (flattened []string) {
-	m := map[string]struct{}{}
+// union concatenates, flattens, and deduplicates the given identifier slices.
+func union(as ...[]uint64) (flattened []uint64) {
+	m := map[uint64]struct{}{}
 	for _, a := range as {
 		for _, v := range a {
 			m[v] = struct{}{}

--- a/internal/indexer/util_test.go
+++ b/internal/indexer/util_test.go
@@ -9,14 +9,18 @@ import (
 
 func TestUnion(t *testing.T) {
 	u := union(
-		[]string{"a1", "a2", "a3"},
-		[]string{"b1", "b2", "b3"},
-		[]string{"a1", "b2", "c3"},
+		[]uint64{10, 20, 30},
+		[]uint64{100, 200, 300},
+		[]uint64{10, 200, 3000},
 	)
-	sort.Strings(u)
+	sort.Slice(u, func(i, j int) bool {
+		return u[i] < u[j]
+	})
 
-	expected := []string{
-		"a1", "a2", "a3", "b1", "b2", "b3", "c3",
+	expected := []uint64{
+		10, 20, 30,
+		100, 200, 300,
+		3000,
 	}
 
 	if diff := cmp.Diff(expected, u); diff != "" {

--- a/internal/indexer/visit.go
+++ b/internal/indexer/visit.go
@@ -5,21 +5,17 @@ import "github.com/efritz/pentimento"
 // visitEachRawFile invokes the given visitor function on each file reachable from the given set of
 // packages. The file info object passed to the given callback function does not have an associated
 // document value. This method prints the progress of the traversal to stdout asynchronously.
-func (i *Indexer) visitEachRawFile(name string, animate bool, fn func(f FileInfo) error) error {
+func (i *Indexer) visitEachRawFile(name string, animate bool, fn func(f FileInfo)) {
 	n := 0
 	for _, p := range i.packages {
 		n += len(p.Syntax)
 	}
 
-	return withTitle(name, animate, func(printer *pentimento.Printer) error {
+	_ = withTitle(name, animate, func(printer *pentimento.Printer) error {
 		c := 0
 		for _, p := range i.packages {
 			for _, f := range p.Syntax {
-				filename := p.Fset.Position(f.Package).Filename
-
-				if err := fn(FileInfo{Package: p, File: f, Filename: filename}); err != nil {
-					return err
-				}
+				fn(FileInfo{Package: p, File: f, Filename: p.Fset.Position(f.Package).Filename})
 
 				c++
 				printProgress(printer, name, c, n)
@@ -33,8 +29,8 @@ func (i *Indexer) visitEachRawFile(name string, animate bool, fn func(f FileInfo
 // visitEachFile invokes the given visitor function on each file reachable from the given set of packages that
 // also has an entry in the indexer's files map. This method prints the progress of the traversal to stdout
 // asynchronously.
-func (i *Indexer) visitEachFile(name string, animate bool, fn func(f FileInfo) error) error {
-	return withTitle(name, animate, func(printer *pentimento.Printer) error {
+func (i *Indexer) visitEachFile(name string, animate bool, fn func(f FileInfo)) {
+	_ = withTitle(name, animate, func(printer *pentimento.Printer) error {
 		processed := map[string]bool{}
 
 		c := 0
@@ -51,9 +47,7 @@ func (i *Indexer) visitEachFile(name string, animate bool, fn func(f FileInfo) e
 					continue
 				}
 
-				if err := fn(FileInfo{Package: p, File: f, Filename: filename, Document: d}); err != nil {
-					return err
-				}
+				fn(FileInfo{Package: p, File: f, Filename: filename, Document: d})
 
 				c++
 				printProgress(printer, name, c, len(i.documents))

--- a/internal/writer/emitter.go
+++ b/internal/writer/emitter.go
@@ -1,7 +1,7 @@
 package writer
 
 import (
-	"strconv"
+	"sync/atomic"
 
 	"github.com/sourcegraph/lsif-go/protocol"
 )
@@ -11,8 +11,8 @@ import (
 // are generated for each constructed element.
 type Emitter struct {
 	writer      JSONWriter
-	id          int
-	numElements int
+	id          uint64
+	numElements uint64
 }
 
 func NewEmitter(writer JSONWriter) *Emitter {
@@ -25,126 +25,125 @@ func (e *Emitter) Flush() error {
 	return e.writer.Flush()
 }
 
-func (e *Emitter) NumElements() int {
-	return e.numElements
+func (e *Emitter) NumElements() uint64 {
+	return atomic.LoadUint64(&e.numElements)
 }
 
-func (e *Emitter) NextID() string {
-	e.id++
-	return strconv.Itoa(e.id)
-}
-
-func (e *Emitter) emit(v interface{}) error {
-	e.numElements++
-	return e.writer.Write(v)
-}
-
-func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewMetaData(id, root, info))
 }
 
-func (e *Emitter) EmitProject(languageID string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitProject(languageID string) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewProject(id, languageID))
 }
 
-func (e *Emitter) EmitDocument(languageID, path string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitDocument(languageID, path string) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewDocument(id, languageID, "file://"+path, nil))
 }
 
-func (e *Emitter) EmitRange(start, end protocol.Pos) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitRange(start, end protocol.Pos) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewRange(id, start, end))
 }
 
-func (e *Emitter) EmitResultSet() (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitResultSet() (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewResultSet(id))
 }
 
-func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewHoverResult(id, contents))
 }
 
-func (e *Emitter) EmitTextDocumentHover(outV, inV string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewTextDocumentHover(id, outV, inV))
 }
 
-func (e *Emitter) EmitDefinitionResult() (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitDefinitionResult() (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewDefinitionResult(id))
 }
 
-func (e *Emitter) EmitTextDocumentDefinition(outV, inV string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewTextDocumentDefinition(id, outV, inV))
 }
 
-func (e *Emitter) EmitReferenceResult() (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitReferenceResult() (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewReferenceResult(id))
 }
 
-func (e *Emitter) EmitTextDocumentReferences(outV, inV string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewTextDocumentReferences(id, outV, inV))
 }
 
-func (e *Emitter) EmitItem(outV string, inVs []string, docID string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewItem(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitItemOfDefinitions(outV string, inVs []string, docID string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitItemOfReferences(outV string, inVs []string, docID string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewItemOfReferences(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewMoniker(id, kind, scheme, identifier))
 }
 
-func (e *Emitter) EmitMonikerEdge(outV, inV string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitMonikerEdge(outV, inV uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewMonikerEdge(id, outV, inV))
 }
 
-func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewPackageInformation(id, packageName, scheme, version))
 }
 
-func (e *Emitter) EmitPackageInformationEdge(outV, inV string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewPackageInformationEdge(id, outV, inV))
 }
 
-func (e *Emitter) EmitContains(outV string, inVs []string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitContains(outV uint64, inVs []uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewContains(id, outV, inVs))
 }
 
-func (e *Emitter) EmitNext(outV, inV string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitNext(outV, inV uint64) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewNext(id, outV, inV))
 }
 
-func (e *Emitter) EmitBeginEvent(scope string, data string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitBeginEvent(scope string, data string) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewEvent(id, "begin", scope, data))
 }
 
-func (e *Emitter) EmitEndEvent(scope string, data string) (string, error) {
-	id := e.NextID()
+func (e *Emitter) EmitEndEvent(scope string, data string) (uint64, error) {
+	id := e.nextID()
 	return id, e.emit(protocol.NewEvent(id, "end", scope, data))
+}
+
+func (e *Emitter) nextID() uint64 {
+	return atomic.AddUint64(&e.id, 1)
+}
+
+func (e *Emitter) emit(v interface{}) error {
+	atomic.AddUint64(&e.numElements, 1)
+	return e.writer.Write(v)
 }

--- a/internal/writer/emitter.go
+++ b/internal/writer/emitter.go
@@ -21,129 +21,146 @@ func NewEmitter(writer JSONWriter) *Emitter {
 	}
 }
 
+func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewMetaData(id, root, info))
+	return id
+}
+
+func (e *Emitter) EmitProject(languageID string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewProject(id, languageID))
+	return id
+}
+
+func (e *Emitter) EmitDocument(languageID, path string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path, nil))
+	return id
+}
+
+func (e *Emitter) EmitRange(start, end protocol.Pos) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewRange(id, start, end))
+	return id
+}
+
+func (e *Emitter) EmitResultSet() uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewResultSet(id))
+	return id
+}
+
+func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewHoverResult(id, contents))
+	return id
+}
+
+func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitDefinitionResult() uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewDefinitionResult(id))
+	return id
+}
+
+func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitReferenceResult() uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewReferenceResult(id))
+	return id
+}
+
+func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
+	return id
+}
+
+func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
+	return id
+}
+
+func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
+	return id
+}
+
+func (e *Emitter) EmitMoniker(kind, scheme, identifier string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
+	return id
+}
+
+func (e *Emitter) EmitMonikerEdge(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
+	return id
+}
+
+func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitContains(outV uint64, inVs []uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewContains(id, outV, inVs))
+	return id
+}
+
+func (e *Emitter) EmitNext(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewNext(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitBeginEvent(scope string, data string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewEvent(id, "begin", scope, data))
+	return id
+}
+
+func (e *Emitter) EmitEndEvent(scope string, data string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewEvent(id, "end", scope, data))
+	return id
+}
+
 func (e *Emitter) Flush() error {
 	return e.writer.Flush()
 }
 
 func (e *Emitter) NumElements() uint64 {
-	return atomic.LoadUint64(&e.numElements)
-}
-
-func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewMetaData(id, root, info))
-}
-
-func (e *Emitter) EmitProject(languageID string) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewProject(id, languageID))
-}
-
-func (e *Emitter) EmitDocument(languageID, path string) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewDocument(id, languageID, "file://"+path, nil))
-}
-
-func (e *Emitter) EmitRange(start, end protocol.Pos) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewRange(id, start, end))
-}
-
-func (e *Emitter) EmitResultSet() (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewResultSet(id))
-}
-
-func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewHoverResult(id, contents))
-}
-
-func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewTextDocumentHover(id, outV, inV))
-}
-
-func (e *Emitter) EmitDefinitionResult() (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewDefinitionResult(id))
-}
-
-func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewTextDocumentDefinition(id, outV, inV))
-}
-
-func (e *Emitter) EmitReferenceResult() (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewReferenceResult(id))
-}
-
-func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewTextDocumentReferences(id, outV, inV))
-}
-
-func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewItem(id, outV, inVs, docID))
-}
-
-func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
-}
-
-func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewItemOfReferences(id, outV, inVs, docID))
-}
-
-func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewMoniker(id, kind, scheme, identifier))
-}
-
-func (e *Emitter) EmitMonikerEdge(outV, inV uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewMonikerEdge(id, outV, inV))
-}
-
-func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewPackageInformation(id, packageName, scheme, version))
-}
-
-func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewPackageInformationEdge(id, outV, inV))
-}
-
-func (e *Emitter) EmitContains(outV uint64, inVs []uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewContains(id, outV, inVs))
-}
-
-func (e *Emitter) EmitNext(outV, inV uint64) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewNext(id, outV, inV))
-}
-
-func (e *Emitter) EmitBeginEvent(scope string, data string) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewEvent(id, "begin", scope, data))
-}
-
-func (e *Emitter) EmitEndEvent(scope string, data string) (uint64, error) {
-	id := e.nextID()
-	return id, e.emit(protocol.NewEvent(id, "end", scope, data))
+	return atomic.LoadUint64(&e.id)
 }
 
 func (e *Emitter) nextID() uint64 {
 	return atomic.AddUint64(&e.id, 1)
-}
-
-func (e *Emitter) emit(v interface{}) error {
-	atomic.AddUint64(&e.numElements, 1)
-	return e.writer.Write(v)
 }

--- a/internal/writer/emitter.go
+++ b/internal/writer/emitter.go
@@ -21,6 +21,10 @@ func NewEmitter(writer JSONWriter) *Emitter {
 	}
 }
 
+func (e *Emitter) Flush() error {
+	return e.writer.Flush()
+}
+
 func (e *Emitter) NumElements() int {
 	return e.numElements
 }

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -13,17 +13,16 @@ var marshaller = jsoniter.ConfigFastest
 // underlying writer as newline-delimited JSON.
 type JSONWriter interface {
 	// Write emits a single vertex or edge value.
-	Write(v interface{}) error
+	Write(v interface{})
 
 	// Flush ensures that all elements have been written to the underlying writer.
 	Flush() error
 }
 
 type jsonWriter struct {
-	wg   sync.WaitGroup
-	ch   chan (interface{})
-	err  error
-	once sync.Once
+	wg  sync.WaitGroup
+	ch  chan (interface{})
+	err error
 }
 
 // channelBufferSize is the nubmer of elements that can be queued to be written.
@@ -41,8 +40,12 @@ func NewJSONWriter(w io.Writer) JSONWriter {
 
 		for v := range ch {
 			if err := encoder.Encode(v); err != nil {
-				jw.once.Do(func() { jw.err = err })
+				jw.err = err
+				break
 			}
+		}
+
+		for range ch {
 		}
 	}()
 
@@ -50,9 +53,8 @@ func NewJSONWriter(w io.Writer) JSONWriter {
 }
 
 // Write emits a single vertex or edge value.
-func (jw *jsonWriter) Write(v interface{}) error {
+func (jw *jsonWriter) Write(v interface{}) {
 	jw.ch <- v
-	return nil
 }
 
 // Flush ensures that all elements have been written to the underlying writer.

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -10,6 +10,9 @@ import (
 type JSONWriter interface {
 	// Write emits a single vertex or edge value.
 	Write(v interface{}) error
+
+	// Flush ensures that all elements have been written to the underlying writer.
+	Flush() error
 }
 
 type jsonWriter struct {
@@ -24,4 +27,9 @@ func NewJSONWriter(w io.Writer) JSONWriter {
 // Write emits a single vertex or edge value.
 func (w *jsonWriter) Write(v interface{}) error {
 	return json.NewEncoder(w.w).Encode(v)
+}
+
+// Flush ensures that all elements have been written to the underlying writer.
+func (w *jsonWriter) Flush() error {
+	return nil
 }

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -26,7 +26,7 @@ type jsonWriter struct {
 	once sync.Once
 }
 
-// TODO - document
+// channelBufferSize is the nubmer of elements that can be queued to be written.
 const channelBufferSize = 512
 
 // NewJSONWriter creates a new JSONWriter wrapping the given writer.

--- a/protocol/contains.go
+++ b/protocol/contains.go
@@ -2,11 +2,11 @@ package protocol
 
 type Contains struct {
 	Edge
-	OutV string   `json:"outV"`
-	InVs []string `json:"inVs"`
+	OutV uint64   `json:"outV"`
+	InVs []uint64 `json:"inVs"`
 }
 
-func NewContains(id, outV string, inVs []string) *Contains {
+func NewContains(id, outV uint64, inVs []uint64) *Contains {
 	return &Contains{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/definition.go
+++ b/protocol/definition.go
@@ -4,7 +4,7 @@ type DefinitionResult struct {
 	Vertex
 }
 
-func NewDefinitionResult(id string) *DefinitionResult {
+func NewDefinitionResult(id uint64) *DefinitionResult {
 	return &DefinitionResult{
 		Vertex: Vertex{
 			Element: Element{
@@ -18,11 +18,11 @@ func NewDefinitionResult(id string) *DefinitionResult {
 
 type TextDocumentDefinition struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentDefinition(id, outV, inV string) *TextDocumentDefinition {
+func NewTextDocumentDefinition(id, outV, inV uint64) *TextDocumentDefinition {
 	return &TextDocumentDefinition{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/document.go
+++ b/protocol/document.go
@@ -9,7 +9,7 @@ type Document struct {
 	Contents   string `json:"contents,omitempty"`
 }
 
-func NewDocument(id, languageID, uri string, contents []byte) *Document {
+func NewDocument(id uint64, languageID, uri string, contents []byte) *Document {
 	d := &Document{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/element.go
+++ b/protocol/element.go
@@ -1,7 +1,7 @@
 package protocol
 
 type Element struct {
-	ID   string      `json:"id"`
+	ID   uint64      `json:"id"`
 	Type ElementType `json:"type"`
 }
 

--- a/protocol/event.go
+++ b/protocol/event.go
@@ -7,7 +7,7 @@ type Event struct {
 	Data  string `json:"data"`
 }
 
-func NewEvent(id, kind, scope, data string) *Event {
+func NewEvent(id uint64, kind, scope, data string) *Event {
 	return &Event{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/hover.go
+++ b/protocol/hover.go
@@ -11,7 +11,7 @@ type hoverResult struct {
 	Contents []MarkedString `json:"contents"`
 }
 
-func NewHoverResult(id string, contents []MarkedString) *HoverResult {
+func NewHoverResult(id uint64, contents []MarkedString) *HoverResult {
 	return &HoverResult{
 		Vertex: Vertex{
 			Element: Element{
@@ -57,11 +57,11 @@ func (m MarkedString) MarshalJSON() ([]byte, error) {
 
 type TextDocumentHover struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentHover(id, outV, inV string) *TextDocumentHover {
+func NewTextDocumentHover(id, outV, inV uint64) *TextDocumentHover {
 	return &TextDocumentHover{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/item.go
+++ b/protocol/item.go
@@ -2,13 +2,13 @@ package protocol
 
 type Item struct {
 	Edge
-	OutV     string   `json:"outV"`
-	InVs     []string `json:"inVs"`
-	Document string   `json:"document"`
+	OutV     uint64   `json:"outV"`
+	InVs     []uint64 `json:"inVs"`
+	Document uint64   `json:"document"`
 	Property string   `json:"property,omitempty"`
 }
 
-func NewItem(id, outV string, inVs []string, document string) *Item {
+func NewItem(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return &Item{
 		Edge: Edge{
 			Element: Element{
@@ -23,17 +23,17 @@ func NewItem(id, outV string, inVs []string, document string) *Item {
 	}
 }
 
-func NewItemWithProperty(id, outV string, inVs []string, document, property string) *Item {
+func NewItemWithProperty(id, outV uint64, inVs []uint64, document uint64, property string) *Item {
 	i := NewItem(id, outV, inVs, document)
 	i.Property = property
 	return i
 }
 
-func NewItemOfDefinitions(id, outV string, inVs []string, document string) *Item {
+func NewItemOfDefinitions(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return NewItemWithProperty(id, outV, inVs, document, "definitions")
 }
 
 // informationand in "references" relationship.
-func NewItemOfReferences(id, outV string, inVs []string, document string) *Item {
+func NewItemOfReferences(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return NewItemWithProperty(id, outV, inVs, document, "references")
 }

--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -18,7 +18,7 @@ type ToolInfo struct {
 	Args    []string `json:"args,omitempty"`
 }
 
-func NewMetaData(id, root string, info ToolInfo) *MetaData {
+func NewMetaData(id uint64, root string, info ToolInfo) *MetaData {
 	return &MetaData{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/moniker.go
+++ b/protocol/moniker.go
@@ -7,7 +7,7 @@ type Moniker struct {
 	Identifier string `json:"identifier"`
 }
 
-func NewMoniker(id, kind, scheme, identifier string) *Moniker {
+func NewMoniker(id uint64, kind, scheme, identifier string) *Moniker {
 	return &Moniker{
 		Vertex: Vertex{
 			Element: Element{
@@ -24,11 +24,11 @@ func NewMoniker(id, kind, scheme, identifier string) *Moniker {
 
 type MonikerEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewMonikerEdge(id, outV, inV string) *MonikerEdge {
+func NewMonikerEdge(id, outV, inV uint64) *MonikerEdge {
 	return &MonikerEdge{
 		Edge: Edge{
 			Element: Element{
@@ -44,11 +44,11 @@ func NewMonikerEdge(id, outV, inV string) *MonikerEdge {
 
 type NextMonikerEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewNextMonikerEdge(id, outV, inV string) *NextMonikerEdge {
+func NewNextMonikerEdge(id, outV, inV uint64) *NextMonikerEdge {
 	return &NextMonikerEdge{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/next.go
+++ b/protocol/next.go
@@ -2,11 +2,11 @@ package protocol
 
 type Next struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewNext(id, outV, inV string) *Next {
+func NewNext(id, outV, inV uint64) *Next {
 	return &Next{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/package_information.go
+++ b/protocol/package_information.go
@@ -3,11 +3,11 @@ package protocol
 type PackageInformation struct {
 	Vertex
 	Name    string `json:"name"`
-	Manager string `json:"manager"`
+	Manager string `json:"manager"` // TODO(efritz) - are we reading this this?
 	Version string `json:"version"`
 }
 
-func NewPackageInformation(id, name, manager, version string) *PackageInformation {
+func NewPackageInformation(id uint64, name, manager, version string) *PackageInformation {
 	return &PackageInformation{
 		Vertex: Vertex{
 			Element: Element{
@@ -24,11 +24,11 @@ func NewPackageInformation(id, name, manager, version string) *PackageInformatio
 
 type PackageInformationEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewPackageInformationEdge(id, outV, inV string) *PackageInformationEdge {
+func NewPackageInformationEdge(id, outV, inV uint64) *PackageInformationEdge {
 	return &PackageInformationEdge{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/project.go
+++ b/protocol/project.go
@@ -5,7 +5,7 @@ type Project struct {
 	Kind string `json:"kind"`
 }
 
-func NewProject(id string, languageID string) *Project {
+func NewProject(id uint64, languageID string) *Project {
 	return &Project{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/range.go
+++ b/protocol/range.go
@@ -11,7 +11,7 @@ type Pos struct {
 	Character int `json:"character"`
 }
 
-func NewRange(id string, start, end Pos) *Range {
+func NewRange(id uint64, start, end Pos) *Range {
 	return &Range{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/reference.go
+++ b/protocol/reference.go
@@ -4,7 +4,7 @@ type ReferenceResult struct {
 	Vertex
 }
 
-func NewReferenceResult(id string) *ResultSet {
+func NewReferenceResult(id uint64) *ResultSet {
 	return &ResultSet{
 		Vertex: Vertex{
 			Element: Element{
@@ -18,11 +18,11 @@ func NewReferenceResult(id string) *ResultSet {
 
 type TextDocumentReferences struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentReferences(id, outV, inV string) *TextDocumentReferences {
+func NewTextDocumentReferences(id, outV, inV uint64) *TextDocumentReferences {
 	return &TextDocumentReferences{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/resultset.go
+++ b/protocol/resultset.go
@@ -4,7 +4,7 @@ type ResultSet struct {
 	Vertex
 }
 
-func NewResultSet(id string) *ResultSet {
+func NewResultSet(id uint64) *ResultSet {
 	return &ResultSet{
 		Vertex: Vertex{
 			Element: Element{


### PR DESCRIPTION
This PR does a few things that allowed us to clean up a bunch of stuff in the indexer:

- Output uint64 identifiers instead of strings
- Structure the emitter/writer so that they can be used from multiple goroutines (will help us parallelize later)
- Remove unused err checks (where they are always nil). This forms a lot of the changes in the indexer pacakge.