### PR TITLE
Output uint64 identifiers instead of strings

### DIFF
--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -186,7 +186,7 @@ func (w *capturingWriter) Write(v interface{}) error {
 }
 
 // findDocumentURIByDocumentID returns the URI of the document with the given ID.
-func findDocumentURIByDocumentID(elements []interface{}, id string) string {
+func findDocumentURIByDocumentID(elements []interface{}, id uint64) string {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Document:
@@ -200,7 +200,7 @@ func findDocumentURIByDocumentID(elements []interface{}, id string) string {
 }
 
 // findRangeByID returns the range with the given identifier.
-func findRangeByID(elements []interface{}, id string) *protocol.Range {
+func findRangeByID(elements []interface{}, id uint64) *protocol.Range {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Range:
@@ -214,7 +214,7 @@ func findRangeByID(elements []interface{}, id string) *protocol.Range {
 }
 
 // findHoverResultByID returns the hover result object with the given identifier.
-func findHoverResultByID(elements []interface{}, id string) *protocol.HoverResult {
+func findHoverResultByID(elements []interface{}, id uint64) *protocol.HoverResult {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.HoverResult:
@@ -228,7 +228,7 @@ func findHoverResultByID(elements []interface{}, id string) *protocol.HoverResul
 }
 
 // findMonikerByID returns the moniker with the given identifier.
-func findMonikerByID(elements []interface{}, id string) *protocol.Moniker {
+func findMonikerByID(elements []interface{}, id uint64) *protocol.Moniker {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Moniker:
@@ -242,7 +242,7 @@ func findMonikerByID(elements []interface{}, id string) *protocol.Moniker {
 }
 
 // findPackageInformationByID returns the moniker with the given identifier.
-func findPackageInformationByID(elements []interface{}, id string) *protocol.PackageInformation {
+func findPackageInformationByID(elements []interface{}, id uint64) *protocol.PackageInformation {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.PackageInformation:
@@ -257,7 +257,7 @@ func findPackageInformationByID(elements []interface{}, id string) *protocol.Pac
 
 // findDefintionRangesByDefinitionResultID returns the ranges attached to the definition result with the given
 // identifier.
-func findDefintionRangesByDefinitionResultID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findDefintionRangesByDefinitionResultID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Item:
@@ -276,7 +276,7 @@ func findDefintionRangesByDefinitionResultID(elements []interface{}, id string) 
 
 // findReferenceRangesByReferenceResultID returns the ranges attached to the reference result with the given
 // identifier.
-func findReferenceRangesByReferenceResultID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findReferenceRangesByReferenceResultID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Item:
@@ -294,7 +294,7 @@ func findReferenceRangesByReferenceResultID(elements []interface{}, id string) (
 }
 
 // findDocumentURIContaining finds the URI of the document containing the given ID.
-func findDocumentURIContaining(elements []interface{}, id string) string {
+func findDocumentURIContaining(elements []interface{}, id uint64) string {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Contains:
@@ -327,7 +327,7 @@ func findRange(elements []interface{}, filename string, startLine, startCharacte
 
 // findHoverResultByRangeOrResultSetID returns the hover result attached to the range or result
 // set with the given identifier.
-func findHoverResultByRangeOrResultSetID(elements []interface{}, id string) *protocol.HoverResult {
+func findHoverResultByRangeOrResultSetID(elements []interface{}, id uint64) *protocol.HoverResult {
 	// First see if we're attached to a hover result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -355,7 +355,7 @@ func findHoverResultByRangeOrResultSetID(elements []interface{}, id string) *pro
 
 // findDefinitionRangesByRangeOrResultSetID returns the definition ranges attached to the range or result set
 // with the given identifier.
-func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	// First see if we're attached to definition result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -381,7 +381,7 @@ func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id string)
 
 // findReferenceRangesByRangeOrResultSetID returns the reference ranges attached to the range or result set with
 // the given identifier.
-func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	// First see if we're attached to reference result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -407,7 +407,7 @@ func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id string) 
 
 // findMonikersByRangeOrReferenceResultID returns the monikers attached to the range or  reference result
 // with the given identifier.
-func findMonikersByRangeOrReferenceResultID(elements []interface{}, id string) (monikers []*protocol.Moniker) {
+func findMonikersByRangeOrReferenceResultID(elements []interface{}, id uint64) (monikers []*protocol.Moniker) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.MonikerEdge:
@@ -433,7 +433,7 @@ func findMonikersByRangeOrReferenceResultID(elements []interface{}, id string) (
 }
 
 // findPackageInformationByMonikerID returns the package information vertexes attached to the moniker with the given identifier.
-func findPackageInformationByMonikerID(elements []interface{}, id string) (packageInformation []*protocol.PackageInformation) {
+func findPackageInformationByMonikerID(elements []interface{}, id uint64) (packageInformation []*protocol.PackageInformation) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.PackageInformationEdge:

--- a/internal/indexer/hover.go
+++ b/internal/indexer/hover.go
@@ -28,13 +28,13 @@ func findExternalHoverContents(hoverLoader *HoverLoader, pkgs []*packages.Packag
 // makeCachedHoverResult returns a hover result vertex identifier. If hover text for the given
 // identifier has not already been emitted, a new vertex is created. Identifiers will share the
 // same hover result if they refer to the same identifier in the same target package.
-func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) (_ string, err error) {
+func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) (_ uint64, err error) {
 	key := makeCacheKey(pkg, obj)
 
 	hoverResultID, ok := i.hoverResultCache[key]
 	if !ok {
 		if hoverResultID, err = i.emitter.EmitHoverResult(fn()); err != nil {
-			return "", errors.Wrap(err, "writer.EmitHoverResult")
+			return 0, errors.Wrap(err, "writer.EmitHoverResult")
 		}
 
 		if key != "" {

--- a/internal/indexer/info.go
+++ b/internal/indexer/info.go
@@ -10,10 +10,10 @@ import (
 
 // Stats summarizes the amount of work done by the indexer.
 type Stats struct {
-	NumPkgs     int
-	NumFiles    int
-	NumDefs     int
-	NumElements int
+	NumPkgs     uint
+	NumFiles    uint
+	NumDefs     uint
+	NumElements uint64
 }
 
 // FileInfo provides context about a particular file.
@@ -27,9 +27,9 @@ type FileInfo struct {
 // DocumentInfo provides context for constructing the contains relationship between
 // a document and the ranges that it contains.
 type DocumentInfo struct {
-	DocumentID         string
-	DefinitionRangeIDs []string
-	ReferenceRangeIDs  []string
+	DocumentID         uint64
+	DefinitionRangeIDs []uint64
+	ReferenceRangeIDs  []uint64
 }
 
 // ObjectInfo provides context about a particular object within a file.
@@ -44,15 +44,15 @@ type ObjectInfo struct {
 // of this shape is keyed by type and identifier in the indexer so that it can be
 // re-retrieved for a range that uses the definition.
 type DefinitionInfo struct {
-	DocumentID  string
-	RangeID     string
-	ResultSetID string
+	DocumentID  uint64
+	RangeID     uint64
+	ResultSetID uint64
 }
 
 // ReferenceResultInfo provides context about a definition range. Each definition and
 // reference range will be added to an object of this shape as it is processed.
 type ReferenceResultInfo struct {
-	ResultSetID        string
-	DefinitionRangeIDs map[string][]string
-	ReferenceRangeIDs  map[string][]string
+	ResultSetID        uint64
+	DefinitionRangeIDs map[uint64][]uint64
+	ReferenceRangeIDs  map[uint64][]uint64
 }

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -13,7 +13,7 @@ import (
 // emitExportMoniker emits an export moniker for the given object linked to the given source
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the current module.
-func (i *Indexer) emitExportMoniker(sourceID string, o ObjectInfo) error {
+func (i *Indexer) emitExportMoniker(sourceID uint64, o ObjectInfo) error {
 	if i.moduleName == "" {
 		// Unknown dependencies, skip export monikers
 		return nil
@@ -31,7 +31,7 @@ func (i *Indexer) emitExportMoniker(sourceID string, o ObjectInfo) error {
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the dependency containing
 // the identifier.
-func (i *Indexer) emitImportMoniker(sourceID string, o ObjectInfo) error {
+func (i *Indexer) emitImportMoniker(sourceID uint64, o ObjectInfo) error {
 	pkg := monikerPackage(o)
 
 	for _, moduleName := range packagePrefixes(pkg) {
@@ -67,11 +67,11 @@ func packagePrefixes(packageName string) []string {
 // ensurePackageInformation returns the identifier of a package information vertex with the
 // give name and version. A vertex will be emitted only if one with the same name not yet
 // been emitted.
-func (i *Indexer) ensurePackageInformation(name, version string) (_ string, err error) {
+func (i *Indexer) ensurePackageInformation(name, version string) (_ uint64, err error) {
 	packageInformationID, ok := i.packageInformationIDs[name]
 	if !ok {
 		if packageInformationID, err = i.emitter.EmitPackageInformation(name, "gomod", version); err != nil {
-			return "", errors.Wrap(err, "writer.EmitPackageInformation")
+			return 0, errors.Wrap(err, "writer.EmitPackageInformation")
 		}
 
 		i.packageInformationIDs[name] = packageInformationID
@@ -83,7 +83,7 @@ func (i *Indexer) ensurePackageInformation(name, version string) (_ string, err 
 // addMonikers emits a moniker vertex with the given identifier, an edge from the moniker
 // to the given package information vertex identifier, and an edge from the given source
 // identifier to the moniker vertex identifier.
-func (i *Indexer) addMonikers(kind, identifier, sourceID, packageID string) error {
+func (i *Indexer) addMonikers(kind, identifier string, sourceID, packageID uint64) error {
 	monikerID, err := i.emitter.EmitMoniker(kind, "gomod", identifier)
 	if err != nil {
 		return errors.Wrap(err, "writer.EmitMoniker")

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -18,7 +18,7 @@ func TestEmitExportMoniker(t *testing.T) {
 		moduleName:            "github.com/sourcegraph/lsif-go",
 		moduleVersion:         "3.14.159",
 		emitter:               writer.NewEmitter(w),
-		packageInformationIDs: map[string]string{},
+		packageInformationIDs: map[string]uint64{},
 	}
 
 	object := types.NewConst(
@@ -29,14 +29,14 @@ func TestEmitExportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitExportMoniker("123", ObjectInfo{
+	if err := indexer.emitExportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
 	}); err != nil {
 		t.Fatalf("unexpected error emitting moniker: %s", err)
 	}
 
-	monikers := findMonikersByRangeOrReferenceResultID(w.elements, "123")
+	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
 		t.Fatalf("could not find moniker")
 	}
@@ -70,7 +70,7 @@ func TestEmitImportMoniker(t *testing.T) {
 			"github.com/test/pkg/sub1": "1.2.3-deadbeef",
 		},
 		emitter:               writer.NewEmitter(w),
-		packageInformationIDs: map[string]string{},
+		packageInformationIDs: map[string]uint64{},
 	}
 
 	object := types.NewConst(
@@ -81,14 +81,14 @@ func TestEmitImportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitImportMoniker("123", ObjectInfo{
+	if err := indexer.emitImportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
 	}); err != nil {
 		t.Fatalf("unexpected error emitting moniker: %s", err)
 	}
 
-	monikers := findMonikersByRangeOrReferenceResultID(w.elements, "123")
+	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
 		t.Fatalf("could not find moniker")
 	}

--- a/internal/indexer/util.go
+++ b/internal/indexer/util.go
@@ -1,8 +1,8 @@
 package indexer
 
-// union concatenates, flattens, and deduplicates the given string slices.
-func union(as ...[]string) (flattened []string) {
-	m := map[string]struct{}{}
+// union concatenates, flattens, and deduplicates the given identifier slices.
+func union(as ...[]uint64) (flattened []uint64) {
+	m := map[uint64]struct{}{}
 	for _, a := range as {
 		for _, v := range a {
 			m[v] = struct{}{}

--- a/internal/indexer/util_test.go
+++ b/internal/indexer/util_test.go
@@ -9,14 +9,18 @@ import (
 
 func TestUnion(t *testing.T) {
 	u := union(
-		[]string{"a1", "a2", "a3"},
-		[]string{"b1", "b2", "b3"},
-		[]string{"a1", "b2", "c3"},
+		[]uint64{10, 20, 30},
+		[]uint64{100, 200, 300},
+		[]uint64{10, 200, 3000},
 	)
-	sort.Strings(u)
+	sort.Slice(u, func(i, j int) bool {
+		return u[i] < u[j]
+	})
 
-	expected := []string{
-		"a1", "a2", "a3", "b1", "b2", "b3", "c3",
+	expected := []uint64{
+		10, 20, 30,
+		100, 200, 300,
+		3000,
 	}
 
 	if diff := cmp.Diff(expected, u); diff != "" {

--- a/internal/writer/emitter.go
+++ b/internal/writer/emitter.go
@@ -1,8 +1,6 @@
 package writer
 
 import (
-	"strconv"
-
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 
@@ -10,9 +8,8 @@ import (
 // JSONWriter instance. Use of this struct guarantees that unique identifiers
 // are generated for each constructed element.
 type Emitter struct {
-	writer      JSONWriter
-	id          int
-	numElements int
+	writer JSONWriter
+	id     uint64
 }
 
 func NewEmitter(writer JSONWriter) *Emitter {
@@ -21,126 +18,121 @@ func NewEmitter(writer JSONWriter) *Emitter {
 	}
 }
 
-func (e *Emitter) NumElements() int {
-	return e.numElements
+func (e *Emitter) NumElements() uint64 {
+	return e.id
 }
 
-func (e *Emitter) NextID() string {
+func (e *Emitter) NextID() uint64 {
 	e.id++
-	return strconv.Itoa(e.id)
+	return e.id
 }
 
-func (e *Emitter) emit(v interface{}) error {
-	e.numElements++
-	return e.writer.Write(v)
-}
-
-func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (string, error) {
+func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewMetaData(id, root, info))
+	return id, e.writer.Write(protocol.NewMetaData(id, root, info))
 }
 
-func (e *Emitter) EmitProject(languageID string) (string, error) {
+func (e *Emitter) EmitProject(languageID string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewProject(id, languageID))
+	return id, e.writer.Write(protocol.NewProject(id, languageID))
 }
 
-func (e *Emitter) EmitDocument(languageID, path string) (string, error) {
+func (e *Emitter) EmitDocument(languageID, path string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewDocument(id, languageID, "file://"+path, nil))
+	return id, e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path, nil))
 }
 
-func (e *Emitter) EmitRange(start, end protocol.Pos) (string, error) {
+func (e *Emitter) EmitRange(start, end protocol.Pos) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewRange(id, start, end))
+	return id, e.writer.Write(protocol.NewRange(id, start, end))
 }
 
-func (e *Emitter) EmitResultSet() (string, error) {
+func (e *Emitter) EmitResultSet() (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewResultSet(id))
+	return id, e.writer.Write(protocol.NewResultSet(id))
 }
 
-func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (string, error) {
+func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewHoverResult(id, contents))
+	return id, e.writer.Write(protocol.NewHoverResult(id, contents))
 }
 
-func (e *Emitter) EmitTextDocumentHover(outV, inV string) (string, error) {
+func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewTextDocumentHover(id, outV, inV))
+	return id, e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
 }
 
-func (e *Emitter) EmitDefinitionResult() (string, error) {
+func (e *Emitter) EmitDefinitionResult() (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewDefinitionResult(id))
+	return id, e.writer.Write(protocol.NewDefinitionResult(id))
 }
 
-func (e *Emitter) EmitTextDocumentDefinition(outV, inV string) (string, error) {
+func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewTextDocumentDefinition(id, outV, inV))
+	return id, e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
 }
 
-func (e *Emitter) EmitReferenceResult() (string, error) {
+func (e *Emitter) EmitReferenceResult() (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewReferenceResult(id))
+	return id, e.writer.Write(protocol.NewReferenceResult(id))
 }
 
-func (e *Emitter) EmitTextDocumentReferences(outV, inV string) (string, error) {
+func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewTextDocumentReferences(id, outV, inV))
+	return id, e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
 }
 
-func (e *Emitter) EmitItem(outV string, inVs []string, docID string) (string, error) {
+func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewItem(id, outV, inVs, docID))
+	return id, e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitItemOfDefinitions(outV string, inVs []string, docID string) (string, error) {
+func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
+	return id, e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitItemOfReferences(outV string, inVs []string, docID string) (string, error) {
+func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewItemOfReferences(id, outV, inVs, docID))
+	return id, e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (string, error) {
+func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewMoniker(id, kind, scheme, identifier))
+	return id, e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
 }
 
-func (e *Emitter) EmitMonikerEdge(outV, inV string) (string, error) {
+func (e *Emitter) EmitMonikerEdge(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewMonikerEdge(id, outV, inV))
+	return id, e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
 }
 
-func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (string, error) {
+func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewPackageInformation(id, packageName, scheme, version))
+	return id, e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
 }
 
-func (e *Emitter) EmitPackageInformationEdge(outV, inV string) (string, error) {
+func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewPackageInformationEdge(id, outV, inV))
+	return id, e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
 }
 
-func (e *Emitter) EmitContains(outV string, inVs []string) (string, error) {
+func (e *Emitter) EmitContains(outV uint64, inVs []uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewContains(id, outV, inVs))
+	return id, e.writer.Write(protocol.NewContains(id, outV, inVs))
 }
 
-func (e *Emitter) EmitNext(outV, inV string) (string, error) {
+func (e *Emitter) EmitNext(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewNext(id, outV, inV))
+	return id, e.writer.Write(protocol.NewNext(id, outV, inV))
 }
 
-func (e *Emitter) EmitBeginEvent(scope string, data string) (string, error) {
+func (e *Emitter) EmitBeginEvent(scope string, data string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewEvent(id, "begin", scope, data))
+	return id, e.writer.Write(protocol.NewEvent(id, "begin", scope, data))
 }
 
-func (e *Emitter) EmitEndEvent(scope string, data string) (string, error) {
+func (e *Emitter) EmitEndEvent(scope string, data string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewEvent(id, "end", scope, data))
+	return id, e.writer.Write(protocol.NewEvent(id, "end", scope, data))
 }

--- a/protocol/contains.go
+++ b/protocol/contains.go
@@ -2,11 +2,11 @@ package protocol
 
 type Contains struct {
 	Edge
-	OutV string   `json:"outV"`
-	InVs []string `json:"inVs"`
+	OutV uint64   `json:"outV"`
+	InVs []uint64 `json:"inVs"`
 }
 
-func NewContains(id, outV string, inVs []string) *Contains {
+func NewContains(id, outV uint64, inVs []uint64) *Contains {
 	return &Contains{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/definition.go
+++ b/protocol/definition.go
@@ -4,7 +4,7 @@ type DefinitionResult struct {
 	Vertex
 }
 
-func NewDefinitionResult(id string) *DefinitionResult {
+func NewDefinitionResult(id uint64) *DefinitionResult {
 	return &DefinitionResult{
 		Vertex: Vertex{
 			Element: Element{
@@ -18,11 +18,11 @@ func NewDefinitionResult(id string) *DefinitionResult {
 
 type TextDocumentDefinition struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentDefinition(id, outV, inV string) *TextDocumentDefinition {
+func NewTextDocumentDefinition(id, outV, inV uint64) *TextDocumentDefinition {
 	return &TextDocumentDefinition{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/document.go
+++ b/protocol/document.go
@@ -9,7 +9,7 @@ type Document struct {
 	Contents   string `json:"contents,omitempty"`
 }
 
-func NewDocument(id, languageID, uri string, contents []byte) *Document {
+func NewDocument(id uint64, languageID, uri string, contents []byte) *Document {
 	d := &Document{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/element.go
+++ b/protocol/element.go
@@ -1,7 +1,7 @@
 package protocol
 
 type Element struct {
-	ID   string      `json:"id"`
+	ID   uint64      `json:"id"`
 	Type ElementType `json:"type"`
 }
 

--- a/protocol/event.go
+++ b/protocol/event.go
@@ -7,7 +7,7 @@ type Event struct {
 	Data  string `json:"data"`
 }
 
-func NewEvent(id, kind, scope, data string) *Event {
+func NewEvent(id uint64, kind, scope, data string) *Event {
 	return &Event{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/hover.go
+++ b/protocol/hover.go
@@ -11,7 +11,7 @@ type hoverResult struct {
 	Contents []MarkedString `json:"contents"`
 }
 
-func NewHoverResult(id string, contents []MarkedString) *HoverResult {
+func NewHoverResult(id uint64, contents []MarkedString) *HoverResult {
 	return &HoverResult{
 		Vertex: Vertex{
 			Element: Element{
@@ -57,11 +57,11 @@ func (m MarkedString) MarshalJSON() ([]byte, error) {
 
 type TextDocumentHover struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentHover(id, outV, inV string) *TextDocumentHover {
+func NewTextDocumentHover(id, outV, inV uint64) *TextDocumentHover {
 	return &TextDocumentHover{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/item.go
+++ b/protocol/item.go
@@ -2,13 +2,13 @@ package protocol
 
 type Item struct {
 	Edge
-	OutV     string   `json:"outV"`
-	InVs     []string `json:"inVs"`
-	Document string   `json:"document"`
+	OutV     uint64   `json:"outV"`
+	InVs     []uint64 `json:"inVs"`
+	Document uint64   `json:"document"`
 	Property string   `json:"property,omitempty"`
 }
 
-func NewItem(id, outV string, inVs []string, document string) *Item {
+func NewItem(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return &Item{
 		Edge: Edge{
 			Element: Element{
@@ -23,17 +23,17 @@ func NewItem(id, outV string, inVs []string, document string) *Item {
 	}
 }
 
-func NewItemWithProperty(id, outV string, inVs []string, document, property string) *Item {
+func NewItemWithProperty(id, outV uint64, inVs []uint64, document uint64, property string) *Item {
 	i := NewItem(id, outV, inVs, document)
 	i.Property = property
 	return i
 }
 
-func NewItemOfDefinitions(id, outV string, inVs []string, document string) *Item {
+func NewItemOfDefinitions(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return NewItemWithProperty(id, outV, inVs, document, "definitions")
 }
 
 // informationand in "references" relationship.
-func NewItemOfReferences(id, outV string, inVs []string, document string) *Item {
+func NewItemOfReferences(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return NewItemWithProperty(id, outV, inVs, document, "references")
 }

--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -18,7 +18,7 @@ type ToolInfo struct {
 	Args    []string `json:"args,omitempty"`
 }
 
-func NewMetaData(id, root string, info ToolInfo) *MetaData {
+func NewMetaData(id uint64, root string, info ToolInfo) *MetaData {
 	return &MetaData{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/moniker.go
+++ b/protocol/moniker.go
@@ -7,7 +7,7 @@ type Moniker struct {
 	Identifier string `json:"identifier"`
 }
 
-func NewMoniker(id, kind, scheme, identifier string) *Moniker {
+func NewMoniker(id uint64, kind, scheme, identifier string) *Moniker {
 	return &Moniker{
 		Vertex: Vertex{
 			Element: Element{
@@ -24,11 +24,11 @@ func NewMoniker(id, kind, scheme, identifier string) *Moniker {
 
 type MonikerEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewMonikerEdge(id, outV, inV string) *MonikerEdge {
+func NewMonikerEdge(id, outV, inV uint64) *MonikerEdge {
 	return &MonikerEdge{
 		Edge: Edge{
 			Element: Element{
@@ -44,11 +44,11 @@ func NewMonikerEdge(id, outV, inV string) *MonikerEdge {
 
 type NextMonikerEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewNextMonikerEdge(id, outV, inV string) *NextMonikerEdge {
+func NewNextMonikerEdge(id, outV, inV uint64) *NextMonikerEdge {
 	return &NextMonikerEdge{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/next.go
+++ b/protocol/next.go
@@ -2,11 +2,11 @@ package protocol
 
 type Next struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewNext(id, outV, inV string) *Next {
+func NewNext(id, outV, inV uint64) *Next {
 	return &Next{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/package_information.go
+++ b/protocol/package_information.go
@@ -7,7 +7,7 @@ type PackageInformation struct {
 	Version string `json:"version"`
 }
 
-func NewPackageInformation(id, name, manager, version string) *PackageInformation {
+func NewPackageInformation(id uint64, name, manager, version string) *PackageInformation {
 	return &PackageInformation{
 		Vertex: Vertex{
 			Element: Element{
@@ -24,11 +24,11 @@ func NewPackageInformation(id, name, manager, version string) *PackageInformatio
 
 type PackageInformationEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewPackageInformationEdge(id, outV, inV string) *PackageInformationEdge {
+func NewPackageInformationEdge(id, outV, inV uint64) *PackageInformationEdge {
 	return &PackageInformationEdge{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/project.go
+++ b/protocol/project.go
@@ -5,7 +5,7 @@ type Project struct {
 	Kind string `json:"kind"`
 }
 
-func NewProject(id string, languageID string) *Project {
+func NewProject(id uint64, languageID string) *Project {
 	return &Project{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/range.go
+++ b/protocol/range.go
@@ -11,7 +11,7 @@ type Pos struct {
 	Character int `json:"character"`
 }
 
-func NewRange(id string, start, end Pos) *Range {
+func NewRange(id uint64, start, end Pos) *Range {
 	return &Range{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/reference.go
+++ b/protocol/reference.go
@@ -4,7 +4,7 @@ type ReferenceResult struct {
 	Vertex
 }
 
-func NewReferenceResult(id string) *ResultSet {
+func NewReferenceResult(id uint64) *ResultSet {
 	return &ResultSet{
 		Vertex: Vertex{
 			Element: Element{
@@ -18,11 +18,11 @@ func NewReferenceResult(id string) *ResultSet {
 
 type TextDocumentReferences struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentReferences(id, outV, inV string) *TextDocumentReferences {
+func NewTextDocumentReferences(id, outV, inV uint64) *TextDocumentReferences {
 	return &TextDocumentReferences{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/resultset.go
+++ b/protocol/resultset.go
@@ -4,7 +4,7 @@ type ResultSet struct {
 	Vertex
 }
 
-func NewResultSet(id string) *ResultSet {
+func NewResultSet(id uint64) *ResultSet {
 	return &ResultSet{
 		Vertex: Vertex{
 			Element: Element{


### PR DESCRIPTION
This saves a few CPU cycles converting and outputting strings. This saves even more cycles in the processor backend as we don't have to intern them into integers. There's also a small output size savings, although when gzipped it's not that much.