### PR TITLE
Buffer writes to the target file

### DIFF
--- a/cmd/lsif-go/index.go
+++ b/cmd/lsif-go/index.go
@@ -55,7 +55,7 @@ func makeIndexer(repositoryRoot, projectRoot, moduleName, moduleVersion string, 
 		moduleName,
 		moduleVersion,
 		dependencies,
-		writer.NewEmitter(writer.NewJSONWriter(out)),
+		writer.NewJSONWriter(out),
 		!noProgress,
 	)
 }

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101
 	github.com/google/go-cmp v0.5.1
+	github.com/json-iterator/go v1.1.10
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3

--- a/go.sum
+++ b/go.sum
@@ -12,11 +12,18 @@ github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101 h1:RylpU+KNJJNEJ
 github.com/efritz/pentimento v0.0.0-20190429011147-ade47d831101/go.mod h1:5ALWO82UZwfAtNRUtwzsWimcrcuYzyieTyyXOXrP6EQ=
 github.com/google/go-cmp v0.5.1 h1:JFrFEBb2xKufg6XkJsJr+WbKb4FQlURi5RUcBveYu9k=
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
+github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
+github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
+github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -26,6 +33,7 @@ github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3/go.mod h1:AIBPxLCk
 github.com/sourcegraph/lsif-go/testdata v0.0.0-20200804185623-bb090d50c787 h1:DsAsuryZ2cohinSATsS8mVlXtJBow7KOKEvUFJrqQAs=
 github.com/sourcegraph/lsif-go/testdata v0.0.0-20200804185623-bb090d50c787/go.mod h1:nhIb9rqlDWCb8yKzltYZQrnI8pmE2xBC/qH5KdPnVJc=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -71,17 +71,19 @@ func findUseByName(t *testing.T, packages []*packages.Package, name string) (*pa
 	return nil, nil
 }
 
-// findObjectInfoByDefinitionName constructs an ObjectInfo value for the definition matching the
-// given name.
-func findObjectInfoByDefinitionName(t *testing.T, name string) ObjectInfo {
-	p, target := findDefinitionByName(t, getTestPackages(t), name)
-	return makeObjectInfo(t, name, p, target)
+// findObjectInfoByDefinitionName constructs an ObjectInfo value for the definition matching
+// the given name.
+func findObjectInfoByDefinitionName(t *testing.T, name string) ([]*packages.Package, ObjectInfo) {
+	packages := getTestPackages(t)
+	p, target := findDefinitionByName(t, packages, name)
+	return packages, makeObjectInfo(t, name, p, target)
 }
 
 // findObjectInfoByUseName constructs an ObjectInfo value for the use matching the given name.
-func findObjectInfoByUseName(t *testing.T, name string) ObjectInfo {
-	p, target := findUseByName(t, getTestPackages(t), name)
-	return makeObjectInfo(t, name, p, target)
+func findObjectInfoByUseName(t *testing.T, name string) ([]*packages.Package, ObjectInfo) {
+	packages := getTestPackages(t)
+	p, target := findUseByName(t, packages, name)
+	return packages, makeObjectInfo(t, name, p, target)
 }
 
 // getFileContaining returns the file containing the given object.
@@ -108,10 +110,10 @@ func makeObjectInfo(t *testing.T, name string, p *packages.Package, target types
 	}
 }
 
-// loadHovers populates and returns a hover loader instance with the text for all definitions
-// in in the given packages.
-func loadHovers(packages []*packages.Package) *HoverLoader {
-	hoverLoader := newHoverLoader()
+// preload populates and returns a Preloader instance with the hover text and moniker
+// paths for all definitions in in the given packages.
+func preload(packages []*packages.Package) *Preloader {
+	preloader := newPreloader()
 	for _, p := range getAllReferencedPackages(packages) {
 		var positions []token.Pos
 		for _, def := range p.TypesInfo.Defs {
@@ -121,11 +123,11 @@ func loadHovers(packages []*packages.Package) *HoverLoader {
 		}
 
 		for _, f := range p.Syntax {
-			hoverLoader.Load(f, positions)
+			preloader.Load(f, positions)
 		}
 	}
 
-	return hoverLoader
+	return preloader
 }
 
 // normalizeDocstring removes leading indentation from each line, removes empty lines,

--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -186,7 +186,7 @@ func (w *capturingWriter) Write(v interface{}) error {
 }
 
 // findDocumentURIByDocumentID returns the URI of the document with the given ID.
-func findDocumentURIByDocumentID(elements []interface{}, id string) string {
+func findDocumentURIByDocumentID(elements []interface{}, id uint64) string {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Document:
@@ -200,7 +200,7 @@ func findDocumentURIByDocumentID(elements []interface{}, id string) string {
 }
 
 // findRangeByID returns the range with the given identifier.
-func findRangeByID(elements []interface{}, id string) *protocol.Range {
+func findRangeByID(elements []interface{}, id uint64) *protocol.Range {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Range:
@@ -214,7 +214,7 @@ func findRangeByID(elements []interface{}, id string) *protocol.Range {
 }
 
 // findHoverResultByID returns the hover result object with the given identifier.
-func findHoverResultByID(elements []interface{}, id string) *protocol.HoverResult {
+func findHoverResultByID(elements []interface{}, id uint64) *protocol.HoverResult {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.HoverResult:
@@ -228,7 +228,7 @@ func findHoverResultByID(elements []interface{}, id string) *protocol.HoverResul
 }
 
 // findMonikerByID returns the moniker with the given identifier.
-func findMonikerByID(elements []interface{}, id string) *protocol.Moniker {
+func findMonikerByID(elements []interface{}, id uint64) *protocol.Moniker {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.Moniker:
@@ -242,7 +242,7 @@ func findMonikerByID(elements []interface{}, id string) *protocol.Moniker {
 }
 
 // findPackageInformationByID returns the moniker with the given identifier.
-func findPackageInformationByID(elements []interface{}, id string) *protocol.PackageInformation {
+func findPackageInformationByID(elements []interface{}, id uint64) *protocol.PackageInformation {
 	for _, elem := range elements {
 		switch v := elem.(type) {
 		case *protocol.PackageInformation:
@@ -257,7 +257,7 @@ func findPackageInformationByID(elements []interface{}, id string) *protocol.Pac
 
 // findDefintionRangesByDefinitionResultID returns the ranges attached to the definition result with the given
 // identifier.
-func findDefintionRangesByDefinitionResultID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findDefintionRangesByDefinitionResultID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Item:
@@ -276,7 +276,7 @@ func findDefintionRangesByDefinitionResultID(elements []interface{}, id string) 
 
 // findReferenceRangesByReferenceResultID returns the ranges attached to the reference result with the given
 // identifier.
-func findReferenceRangesByReferenceResultID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findReferenceRangesByReferenceResultID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Item:
@@ -294,7 +294,7 @@ func findReferenceRangesByReferenceResultID(elements []interface{}, id string) (
 }
 
 // findDocumentURIContaining finds the URI of the document containing the given ID.
-func findDocumentURIContaining(elements []interface{}, id string) string {
+func findDocumentURIContaining(elements []interface{}, id uint64) string {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.Contains:
@@ -327,7 +327,7 @@ func findRange(elements []interface{}, filename string, startLine, startCharacte
 
 // findHoverResultByRangeOrResultSetID returns the hover result attached to the range or result
 // set with the given identifier.
-func findHoverResultByRangeOrResultSetID(elements []interface{}, id string) *protocol.HoverResult {
+func findHoverResultByRangeOrResultSetID(elements []interface{}, id uint64) *protocol.HoverResult {
 	// First see if we're attached to a hover result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -355,7 +355,7 @@ func findHoverResultByRangeOrResultSetID(elements []interface{}, id string) *pro
 
 // findDefinitionRangesByRangeOrResultSetID returns the definition ranges attached to the range or result set
 // with the given identifier.
-func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	// First see if we're attached to definition result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -381,7 +381,7 @@ func findDefinitionRangesByRangeOrResultSetID(elements []interface{}, id string)
 
 // findReferenceRangesByRangeOrResultSetID returns the reference ranges attached to the range or result set with
 // the given identifier.
-func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id string) (ranges []*protocol.Range) {
+func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id uint64) (ranges []*protocol.Range) {
 	// First see if we're attached to reference result directly
 	for _, elem := range elements {
 		switch e := elem.(type) {
@@ -407,7 +407,7 @@ func findReferenceRangesByRangeOrResultSetID(elements []interface{}, id string) 
 
 // findMonikersByRangeOrReferenceResultID returns the monikers attached to the range or  reference result
 // with the given identifier.
-func findMonikersByRangeOrReferenceResultID(elements []interface{}, id string) (monikers []*protocol.Moniker) {
+func findMonikersByRangeOrReferenceResultID(elements []interface{}, id uint64) (monikers []*protocol.Moniker) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.MonikerEdge:
@@ -433,7 +433,7 @@ func findMonikersByRangeOrReferenceResultID(elements []interface{}, id string) (
 }
 
 // findPackageInformationByMonikerID returns the package information vertexes attached to the moniker with the given identifier.
-func findPackageInformationByMonikerID(elements []interface{}, id string) (packageInformation []*protocol.PackageInformation) {
+func findPackageInformationByMonikerID(elements []interface{}, id uint64) (packageInformation []*protocol.PackageInformation) {
 	for _, elem := range elements {
 		switch e := elem.(type) {
 		case *protocol.PackageInformationEdge:

--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -180,8 +180,11 @@ type capturingWriter struct {
 	elements []interface{}
 }
 
-func (w *capturingWriter) Write(v interface{}) error {
+func (w *capturingWriter) Write(v interface{}) {
 	w.elements = append(w.elements, v)
+}
+
+func (w *capturingWriter) Flush() error {
 	return nil
 }
 

--- a/internal/indexer/hover.go
+++ b/internal/indexer/hover.go
@@ -27,11 +27,11 @@ func findExternalHoverContents(hoverLoader *HoverLoader, pkgs []*packages.Packag
 // makeCachedHoverResult returns a hover result vertex identifier. If hover text for the given
 // identifier has not already been emitted, a new vertex is created. Identifiers will share the
 // same hover result if they refer to the same identifier in the same target package.
-func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) (_ uint64, err error) {
+func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) uint64 {
 	key := makeCacheKey(pkg, obj)
 
 	if hoverResultID, ok := i.hoverResultCache[key]; ok {
-		return hoverResultID, nil
+		return hoverResultID
 	}
 
 	hoverResultID := i.emitter.EmitHoverResult(fn())
@@ -40,7 +40,7 @@ func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn
 		i.hoverResultCache[key] = hoverResultID
 	}
 
-	return hoverResultID, nil
+	return hoverResultID
 }
 
 // makeCacheKey returns a string uniquely representing the given package and object pair. If

--- a/internal/indexer/hover.go
+++ b/internal/indexer/hover.go
@@ -10,17 +10,17 @@ import (
 
 // findHoverContents returns the hover contents of the given object. This method is not cached
 // and should only be called wrapped in a call to makeCachedHoverResult.
-func findHoverContents(hoverLoader *HoverLoader, pkgs []*packages.Package, o ObjectInfo) []protocol.MarkedString {
+func findHoverContents(preloader *Preloader, pkgs []*packages.Package, o ObjectInfo) []protocol.MarkedString {
 	signature, extra := typeString(o.Object)
-	docstring := findDocstring(hoverLoader, pkgs, o)
+	docstring := findDocstring(preloader, pkgs, o)
 	return toMarkedString(signature, docstring, extra)
 }
 
 // findExternalHoverContents returns the hover contents of the given object defined in the given
 // package. This method is not cached and should only be called wrapped in a call to makeCachedHoverResult.
-func findExternalHoverContents(hoverLoader *HoverLoader, pkgs []*packages.Package, o ObjectInfo) []protocol.MarkedString {
+func findExternalHoverContents(preloader *Preloader, pkgs []*packages.Package, o ObjectInfo) []protocol.MarkedString {
 	signature, extra := typeString(o.Object)
-	docstring := findExternalDocstring(hoverLoader, pkgs, o)
+	docstring := findExternalDocstring(preloader, pkgs, o)
 	return toMarkedString(signature, docstring, extra)
 }
 
@@ -62,7 +62,7 @@ func makeCacheKey(pkg *types.Package, obj types.Object) string {
 
 // findDocstring extracts the comments form the given object. It is assumed that this object is
 // declared in an index target (otherwise, findExternalDocstring should be called).
-func findDocstring(hoverLoader *HoverLoader, pkgs []*packages.Package, o ObjectInfo) string {
+func findDocstring(preloader *Preloader, pkgs []*packages.Package, o ObjectInfo) string {
 	if o.Object == nil {
 		return ""
 	}
@@ -73,12 +73,12 @@ func findDocstring(hoverLoader *HoverLoader, pkgs []*packages.Package, o ObjectI
 	}
 
 	// Resolve the object o into its respective ast.Node
-	return hoverLoader.Text(o.File, o.Object.Pos())
+	return preloader.Text(o.File, o.Object.Pos())
 }
 
 // findExternalDocstring extracts the comments form the given object. It is assumed that this object is
 // declared in a dependency.
-func findExternalDocstring(hoverLoader *HoverLoader, pkgs []*packages.Package, o ObjectInfo) string {
+func findExternalDocstring(preloader *Preloader, pkgs []*packages.Package, o ObjectInfo) string {
 	if o.Object == nil {
 		return ""
 	}
@@ -90,7 +90,7 @@ func findExternalDocstring(hoverLoader *HoverLoader, pkgs []*packages.Package, o
 
 	if target := o.Package.Imports[o.Object.Pkg().Path()]; target != nil {
 		// Resolve the object o into its respective ast.Node
-		return hoverLoader.TextFromPackage(target, o.Object.Pos())
+		return preloader.TextFromPackage(target, o.Object.Pos())
 	}
 
 	return ""

--- a/internal/indexer/hover.go
+++ b/internal/indexer/hover.go
@@ -28,13 +28,13 @@ func findExternalHoverContents(hoverLoader *HoverLoader, pkgs []*packages.Packag
 // makeCachedHoverResult returns a hover result vertex identifier. If hover text for the given
 // identifier has not already been emitted, a new vertex is created. Identifiers will share the
 // same hover result if they refer to the same identifier in the same target package.
-func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) (_ string, err error) {
+func (i *Indexer) makeCachedHoverResult(pkg *types.Package, obj types.Object, fn func() []protocol.MarkedString) (_ uint64, err error) {
 	key := makeCacheKey(pkg, obj)
 
 	hoverResultID, ok := i.hoverResultCache[key]
 	if !ok {
 		if hoverResultID, err = i.emitter.EmitHoverResult(fn()); err != nil {
-			return "", errors.Wrap(err, "writer.EmitHoverResult")
+			return 0, errors.Wrap(err, "writer.EmitHoverResult")
 		}
 
 		if key != "" {

--- a/internal/indexer/hover_test.go
+++ b/internal/indexer/hover_test.go
@@ -14,7 +14,7 @@ func TestFindDocstring(t *testing.T) {
 		ParallelizableFunc is a function that can be called concurrently with other instances
 		of this function type.
 	`)
-	if text := normalizeDocstring(findDocstring(loadHovers(packages), packages, o)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, o)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -25,7 +25,7 @@ func TestFindDocstringInternalPackageName(t *testing.T) {
 	o := makeObjectInfo(t, "secret", p, target)
 
 	expectedText := normalizeDocstring(`secret is a package that holds secrets.`)
-	if text := normalizeDocstring(findDocstring(loadHovers(packages), packages, o)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, o)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -41,7 +41,7 @@ func TestFindDocstringExternalPackageName(t *testing.T) {
 		Higher-level synchronization is better done via channels and communication.
 		Values containing the types defined in this package should not be copied.
 	`)
-	if text := normalizeDocstring(findDocstring(loadHovers(packages), packages, o)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, o)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -62,7 +62,7 @@ func TestFindExternalDocstring(t *testing.T) {
 		At the same time, Wait can be used to block until all goroutines have finished.
 		A WaitGroup must not be copied after first use.
 	`)
-	if text := normalizeDocstring(findExternalDocstring(loadHovers(packages), packages, o)); text != expectedText {
+	if text := normalizeDocstring(findExternalDocstring(preload(packages), packages, o)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -84,37 +84,14 @@ func (i *Indexer) Index() (*Stats, error) {
 		return nil, errors.Wrap(err, "loadPackages")
 	}
 
-	if err := i.emitMetadataAndProjectVertex(); err != nil {
-		return nil, errors.Wrap(err, "emitMetadataAndProjectVertex")
-	}
-
-	if err := i.emitDocuments(); err != nil {
-		return nil, errors.Wrap(err, "emitDocuments")
-	}
-
-	if err := i.addImports(); err != nil {
-		return nil, errors.Wrap(err, "addImports")
-	}
-
-	if err := i.preloadHoverText(); err != nil {
-		return nil, errors.Wrap(err, "preloadHoverText")
-	}
-
-	if err := i.indexDefinitions(); err != nil {
-		return nil, errors.Wrap(err, "indexDefinitions")
-	}
-
-	if err := i.indexReferences(); err != nil {
-		return nil, errors.Wrap(err, "indexReferences")
-	}
-
-	if err := i.linkReferenceResultsToRanges(); err != nil {
-		return nil, errors.Wrap(err, "linkReferenceResultsToRanges")
-	}
-
-	if err := i.emitContains(); err != nil {
-		return nil, errors.Wrap(err, "emitContains")
-	}
+	i.emitMetadataAndProjectVertex()
+	i.emitDocuments()
+	i.addImports()
+	i.preloadHoverText()
+	i.indexDefinitions()
+	i.indexReferences()
+	i.linkReferenceResultsToRanges()
+	i.emitContains()
 
 	if err := i.emitter.Flush(); err != nil {
 		return nil, errors.Wrap(err, "emitter.Flush")
@@ -144,52 +121,50 @@ func (i *Indexer) loadPackages() error {
 
 // emitMetadata emits a metadata and project vertex. This method returns the identifier of the project
 // vertex, which is needed to construct the project/document contains relation later.
-func (i *Indexer) emitMetadataAndProjectVertex() (err error) {
+func (i *Indexer) emitMetadataAndProjectVertex() {
 	i.emitter.EmitMetaData("file://"+i.repositoryRoot, i.toolInfo)
 	i.projectID = i.emitter.EmitProject(languageGo)
-	return nil
 }
 
 // emitDocuments emits a document vertex for each file for the loaded packages and a contains relation
 // to the project vertex emitted by emitMetadataAndProjectVertex. This also adds entries into the files
 // and ranges map for each document. Methods should skip any document that does not have a file entry as
 // it may fall outside of the project root (and is thus not properly indexable).
-func (i *Indexer) emitDocuments() error {
-	return i.visitEachRawFile("Emitting documents", i.animate, i.emitDocument)
+func (i *Indexer) emitDocuments() {
+	i.visitEachRawFile("Emitting documents", i.animate, i.emitDocument)
 }
 
 // emitDocument emits a document vertex and a contains relation to the enclosing project. This method
 // also prepares the documents and ranges maps (alternatively: this method must be called before any
 // other method that requires the filename key be present in either map).
-func (i *Indexer) emitDocument(f FileInfo) error {
+func (i *Indexer) emitDocument(f FileInfo) {
 	// Emit each document only once
 	if _, ok := i.documents[f.Filename]; ok {
-		return nil
+		return
 	}
 
 	// Indexing test files means that we're also indexing the code _generated_ by go test;
 	// e.g. file://Users/efritz/Library/Caches/go-build/07/{64-character identifier}-d. Skip
 	// These files as they won't be navigable outside of the machine that indexed the project.
 	if !strings.HasPrefix(f.Filename, i.projectRoot) {
-		return nil
+		return
 	}
 
 	documentID := i.emitter.EmitDocument(languageGo, f.Filename)
 	_ = i.emitter.EmitContains(i.projectID, []uint64{documentID})
 	i.documents[f.Filename] = &DocumentInfo{DocumentID: documentID}
 	i.ranges[f.Filename] = map[int]uint64{}
-	return nil
 }
 
 // addImports modifies the definitions map of each file to include entries for import statements so
 // they can be indexed uniformly in subsequent steps.
-func (i *Indexer) addImports() error {
-	return i.visitEachFile("Adding import definitions", i.animate, i.addImportsToFile)
+func (i *Indexer) addImports() {
+	i.visitEachFile("Adding import definitions", i.animate, i.addImportsToFile)
 }
 
 // addImportsToFile modifies the definitions map of the given file to include entries for import
 // statements so they can be indexed uniformly in subsequent steps.
-func (i *Indexer) addImportsToFile(f FileInfo) error {
+func (i *Indexer) addImportsToFile(f FileInfo) {
 	for _, spec := range f.File.Imports {
 		pkg := f.Package.Imports[strings.Trim(spec.Path.Value, `"`)]
 		if pkg == nil {
@@ -200,8 +175,6 @@ func (i *Indexer) addImportsToFile(f FileInfo) error {
 		ident := &ast.Ident{NamePos: spec.Pos(), Name: name, Obj: ast.NewObj(ast.Pkg, name)}
 		f.Package.TypesInfo.Defs[ident] = types.NewPkgName(spec.Pos(), f.Package.Types, name, pkg.Types)
 	}
-
-	return nil
 }
 
 // importSpecName extracts the name from the given import spec.
@@ -268,13 +241,12 @@ func getAllReferencedPackages(pkgs []*packages.Package) (flattened []*packages.P
 // indexDefinitions emits data for each definition in an index target package. This will emit
 // a result set, a definition result, a hover result, and export monikers attached to each range.
 // This method will also populate each document's definition range identifier slice.
-func (i *Indexer) indexDefinitions() error {
-	return i.visitEachFile("Indexing definitions", i.animate, i.indexDefinitionsForFile)
+func (i *Indexer) indexDefinitions() {
+	i.visitEachFile("Indexing definitions", i.animate, i.indexDefinitionsForFile)
 }
 
 // indexDefinitions emits data for each definition within the given document.
-func (i *Indexer) indexDefinitionsForFile(f FileInfo) error {
-	var rangeIDs []uint64
+func (i *Indexer) indexDefinitionsForFile(f FileInfo) {
 	for ident, obj := range f.Package.TypesInfo.Defs {
 		ipos := f.Package.Fset.Position(ident.Pos())
 
@@ -288,38 +260,27 @@ func (i *Indexer) indexDefinitionsForFile(f FileInfo) error {
 			continue
 		}
 
-		rangeID, err := i.indexDefinition(ObjectInfo{
+		f.Document.DefinitionRangeIDs = append(f.Document.DefinitionRangeIDs, i.indexDefinition(ObjectInfo{
 			FileInfo: f,
 			Position: ipos,
 			Object:   obj,
 			Ident:    ident,
-		})
-		if err != nil {
-			return errors.Wrap(err, "indexDefinition")
-		}
-
-		rangeIDs = append(rangeIDs, rangeID)
+		}))
 	}
-
-	f.Document.DefinitionRangeIDs = append(f.Document.DefinitionRangeIDs, rangeIDs...)
-	return nil
 }
 
 // indexDefinition emits data for the given definition object.
-func (i *Indexer) indexDefinition(o ObjectInfo) (uint64, error) {
-	rangeID := i.emitter.EmitRange(rangeForObject(o))
-	resultSetID := i.emitter.EmitResultSet()
-	defResultID := i.emitter.EmitDefinitionResult()
-
+func (i *Indexer) indexDefinition(o ObjectInfo) uint64 {
 	// Create a hover result vertex and cache the result identifier keyed by the definition location.
 	// Caching this gives us a big win for package documentation, which is likely to be large and is
 	// repeated at each import and selector within referenced files.
-	hoverResultID, err := i.makeCachedHoverResult(nil, o.Object, func() []protocol.MarkedString {
+	hoverResultID := i.makeCachedHoverResult(nil, o.Object, func() []protocol.MarkedString {
 		return findHoverContents(i.hoverLoader, i.packages, o)
 	})
-	if err != nil {
-		return 0, errors.Wrap(err, "findContents")
-	}
+
+	rangeID := i.emitter.EmitRange(rangeForObject(o))
+	resultSetID := i.emitter.EmitResultSet()
+	defResultID := i.emitter.EmitDefinitionResult()
 
 	_ = i.emitter.EmitNext(rangeID, resultSetID)
 	_ = i.emitter.EmitTextDocumentDefinition(resultSetID, defResultID)
@@ -327,17 +288,11 @@ func (i *Indexer) indexDefinition(o ObjectInfo) (uint64, error) {
 	_ = i.emitter.EmitTextDocumentHover(resultSetID, hoverResultID)
 
 	if _, ok := o.Object.(*types.PkgName); ok {
-		// Emit import moniker attached to result set
-		if err := i.emitImportMoniker(resultSetID, o); err != nil {
-			return 0, errors.Wrap(err, "emitImportMoniker")
-		}
+		i.emitImportMoniker(resultSetID, o)
 	}
 
 	if o.Ident.IsExported() {
-		// Emit export moniker attached to result set
-		if err := i.emitExportMoniker(resultSetID, o); err != nil {
-			return 0, errors.Wrap(err, "emitExportMoniker")
-		}
+		i.emitExportMoniker(resultSetID, o)
 	}
 
 	i.setDefinitionInfo(o.Ident, o.Object, &DefinitionInfo{
@@ -353,7 +308,7 @@ func (i *Indexer) indexDefinition(o ObjectInfo) (uint64, error) {
 	}
 
 	i.ranges[o.Filename][o.Position.Offset] = rangeID
-	return rangeID, err
+	return rangeID
 }
 
 // setDefinitionInfo stashes the given definition info indexed by the given object type and name.
@@ -380,13 +335,12 @@ func (i *Indexer) setDefinitionInfo(ident *ast.Ident, obj types.Object, d *Defin
 // the range to a local definition (if one exists), or will emit a result set, a reference result,
 // a hover result, and import monikers (for external definitions). This method will also populate
 // each document's reference range identifier slice.
-func (i *Indexer) indexReferences() error {
-	return i.visitEachFile("Indexing references", i.animate, i.indexReferencesForFile)
+func (i *Indexer) indexReferences() {
+	i.visitEachFile("Indexing references", i.animate, i.indexReferencesForFile)
 }
 
 // indexReferencesForFile emits data for each reference within the given document.
-func (i *Indexer) indexReferencesForFile(f FileInfo) error {
-	var rangeIDs []uint64
+func (i *Indexer) indexReferencesForFile(f FileInfo) {
 	for ident, obj := range f.Package.TypesInfo.Uses {
 		ipos := f.Package.Fset.Position(ident.Pos())
 
@@ -395,28 +349,19 @@ func (i *Indexer) indexReferencesForFile(f FileInfo) error {
 			continue
 		}
 
-		rangeID, ok, err := i.indexReference(ObjectInfo{
+		if rangeID, ok := i.indexReference(ObjectInfo{
 			FileInfo: f,
 			Position: ipos,
 			Object:   obj,
 			Ident:    ident,
-		})
-		if err != nil {
-			return errors.Wrap(err, "indexReference")
+		}); ok {
+			f.Document.ReferenceRangeIDs = append(f.Document.ReferenceRangeIDs, rangeID)
 		}
-		if !ok {
-			continue
-		}
-
-		rangeIDs = append(rangeIDs, rangeID)
 	}
-
-	f.Document.ReferenceRangeIDs = append(f.Document.ReferenceRangeIDs, rangeIDs...)
-	return nil
 }
 
 // indexReference emits data for the given reference object.
-func (i *Indexer) indexReference(o ObjectInfo) (uint64, bool, error) {
+func (i *Indexer) indexReference(o ObjectInfo) (uint64, bool) {
 	if def := i.getDefinitionInfo(o.Object); def != nil {
 		return i.indexReferenceToDefinition(o, def)
 	}
@@ -448,86 +393,69 @@ func (i *Indexer) getDefinitionInfo(obj types.Object) *DefinitionInfo {
 
 // indexReferenceToDefinition emits data for the given reference object that is defined within
 // an index target package.
-func (i *Indexer) indexReferenceToDefinition(o ObjectInfo, d *DefinitionInfo) (uint64, bool, error) {
-	rangeID, err := i.ensureRangeFor(o)
-	if err != nil {
-		return 0, false, errors.Wrap(err, "ensureRangeFor")
-	}
-
+func (i *Indexer) indexReferenceToDefinition(o ObjectInfo, d *DefinitionInfo) (uint64, bool) {
+	rangeID := i.ensureRangeFor(o)
 	_ = i.emitter.EmitNext(rangeID, d.ResultSetID)
 
 	if refResult := i.referenceResults[d.RangeID]; refResult != nil {
 		refResult.ReferenceRangeIDs[o.FileInfo.Document.DocumentID] = append(refResult.ReferenceRangeIDs[o.FileInfo.Document.DocumentID], rangeID)
 	}
 
-	return rangeID, true, nil
+	return rangeID, true
 }
 
 // indexReferenceToExternalDefinition emits data for the given reference object that is not defined
 // within an index target package. This definition _may_ be resolvable by scanning dependencies, but
 // it is not guaranteed.
-func (i *Indexer) indexReferenceToExternalDefinition(o ObjectInfo) (uint64, bool, error) {
+func (i *Indexer) indexReferenceToExternalDefinition(o ObjectInfo) (uint64, bool) {
 	definitionPkg := o.Object.Pkg()
 	if definitionPkg == nil {
-		return 0, false, nil
+		return 0, false
 	}
-
-	rangeID, err := i.ensureRangeFor(o)
-	if err != nil {
-		return 0, false, errors.Wrap(err, "ensureRangeFor")
-	}
-
-	refResultID := i.emitter.EmitReferenceResult()
 
 	// Create a or retreive a hover result identifier keyed by the target object's identifier
 	// (scoped ot the object's package name). Caching this gives us another big win as some
 	// methods imported from other packages are likely to be used many times in a dependent
 	// project (e.g., context.Context, http.Request, etc).
-	hoverResultID, err := i.makeCachedHoverResult(definitionPkg, o.Object, func() []protocol.MarkedString {
+	hoverResultID := i.makeCachedHoverResult(definitionPkg, o.Object, func() []protocol.MarkedString {
 		return findExternalHoverContents(i.hoverLoader, i.packages, o)
 	})
-	if err != nil {
-		return 0, false, errors.Wrap(err, "externalHoverContents")
-	}
 
+	rangeID := i.ensureRangeFor(o)
+	refResultID := i.emitter.EmitReferenceResult()
 	_ = i.emitter.EmitTextDocumentReferences(rangeID, refResultID)
 	_ = i.emitter.EmitItemOfReferences(refResultID, []uint64{rangeID}, o.FileInfo.Document.DocumentID)
 
 	if hoverResultID != 0 {
-		// Link range -> hover result
 		_ = i.emitter.EmitTextDocumentHover(rangeID, hoverResultID)
 	}
 
-	// Emit import moniker attached to result set
-	if err := i.emitImportMoniker(rangeID, o); err != nil {
-		return 0, false, errors.Wrap(err, "emitImportMoniker")
-	}
-
-	return rangeID, true, nil
+	i.emitImportMoniker(rangeID, o)
+	return rangeID, true
 }
 
 // ensureRangeFor returns a range identifier for the given object. If a range for the object has
 // not been emitted, a new vertex is created.
-func (i *Indexer) ensureRangeFor(o ObjectInfo) (_ uint64, err error) {
+func (i *Indexer) ensureRangeFor(o ObjectInfo) uint64 {
 	if rangeID, ok := i.ranges[o.Filename][o.Position.Offset]; ok {
-		return rangeID, nil
+		return rangeID
 	}
 
 	rangeID := i.emitter.EmitRange(rangeForObject(o))
 	i.ranges[o.Filename][o.Position.Offset] = rangeID
-	return rangeID, nil
+	return rangeID
 }
 
 // linkReferenceResultsToRanges emits textDocument/definition and textDocument/hover relations
 // for each indexed reference result.
-func (i *Indexer) linkReferenceResultsToRanges() error {
+func (i *Indexer) linkReferenceResultsToRanges() {
 	// TODO(efritz) - emit in a more efficient order
-	return i.visitEachFile("Linking reference results to ranges", i.animate, i.linkReferenceResultsToRangesInFile)
+	i.visitEachFile("Linking reference results to ranges", i.animate, i.linkReferenceResultsToRangesInFile)
 }
 
 // linkReferenceResultsToRangesInFile links textDocument/definition and textDocument/hover, relations
 // for each indexed reference result in the given document.
-func (i *Indexer) linkReferenceResultsToRangesInFile(f FileInfo) error {
+func (i *Indexer) linkReferenceResultsToRangesInFile(f FileInfo) {
 	for _, rangeID := range f.Document.DefinitionRangeIDs {
 		referenceResult, ok := i.referenceResults[rangeID]
 		if !ok {
@@ -545,24 +473,19 @@ func (i *Indexer) linkReferenceResultsToRangesInFile(f FileInfo) error {
 			_ = i.emitter.EmitItemOfReferences(refResultID, rangeIDs, documentID)
 		}
 	}
-
-	return nil
 }
 
 // emitContains emits the contains relationship for all documents and the ranges that it contains.
-func (i *Indexer) emitContains() error {
-	return i.visitEachFile("Emitting contains relations", i.animate, i.emitContainsForFile)
+func (i *Indexer) emitContains() {
+	i.visitEachFile("Emitting contains relations", i.animate, i.emitContainsForFile)
 }
 
 // emitContainsForFile emits a contains edge between the given document and the ranges that in contains.
 // No edge is emitted if the document contains no ranges.
-func (i *Indexer) emitContainsForFile(f FileInfo) error {
-	if len(f.Document.DefinitionRangeIDs) == 0 && len(f.Document.ReferenceRangeIDs) == 0 {
-		return nil
+func (i *Indexer) emitContainsForFile(f FileInfo) {
+	if len(f.Document.DefinitionRangeIDs) > 0 || len(f.Document.ReferenceRangeIDs) > 0 {
+		_ = i.emitter.EmitContains(f.Document.DocumentID, union(f.Document.DefinitionRangeIDs, f.Document.ReferenceRangeIDs))
 	}
-
-	_ = i.emitter.EmitContains(f.Document.DocumentID, union(f.Document.DefinitionRangeIDs, f.Document.ReferenceRangeIDs))
-	return nil
 }
 
 // stats returns a Stats object with the number of packages, files, and elements analyzed/emitted.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -151,7 +151,6 @@ func (i *Indexer) emitDocument(f FileInfo) {
 	}
 
 	documentID := i.emitter.EmitDocument(languageGo, f.Filename)
-	_ = i.emitter.EmitContains(i.projectID, []uint64{documentID})
 	i.documents[f.Filename] = &DocumentInfo{DocumentID: documentID}
 	i.ranges[f.Filename] = map[int]uint64{}
 }
@@ -478,6 +477,9 @@ func (i *Indexer) linkReferenceResultsToRangesInFile(f FileInfo) {
 // emitContains emits the contains relationship for all documents and the ranges that it contains.
 func (i *Indexer) emitContains() {
 	i.visitEachFile("Emitting contains relations", i.animate, i.emitContainsForFile)
+
+	// TODO(efritz) - think about printing a title here
+	i.emitContainsForProject()
 }
 
 // emitContainsForFile emits a contains edge between the given document and the ranges that in contains.
@@ -485,6 +487,18 @@ func (i *Indexer) emitContains() {
 func (i *Indexer) emitContainsForFile(f FileInfo) {
 	if len(f.Document.DefinitionRangeIDs) > 0 || len(f.Document.ReferenceRangeIDs) > 0 {
 		_ = i.emitter.EmitContains(f.Document.DocumentID, union(f.Document.DefinitionRangeIDs, f.Document.ReferenceRangeIDs))
+	}
+}
+
+// emitContainsForProject emits a contains edge between the target project and all indexed documents.
+func (i *Indexer) emitContainsForProject() {
+	var documentIDs []uint64
+	for _, info := range i.documents {
+		documentIDs = append(documentIDs, info.DocumentID)
+	}
+
+	if len(documentIDs) > 0 {
+		_ = i.emitter.EmitContains(i.projectID, documentIDs)
 	}
 }
 

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -113,7 +113,26 @@ func TestIndexer(t *testing.T) {
 		compareRange(t, references[3], 27, 1, 27, 3)  // wg.Wait()
 	})
 
-	// TODO(efritz) - add additional tests
+	t.Run("check NestedB monikers", func(t *testing.T) {
+		r := findRange(w.elements, "file://"+filepath.Join(projectRoot, "data.go"), 26, 2)
+		if r == nil {
+			t.Fatalf("could not find target range")
+		}
+
+		monikers := findMonikersByRangeOrReferenceResultID(w.elements, r.ID)
+		if len(monikers) != 1 {
+			t.Errorf("incorrect moniker count. want=%d have=%d", 1, len(monikers))
+		}
+
+		if value := monikers[0].Scheme; value != "gomod" {
+			t.Errorf("incorrect scheme. want=%q have=%q", "gomod", value)
+		}
+
+		expectedIdentifier := "github.com/sourcegraph/lsif-go/internal/testdata:TestStruct.FieldWithAnonymousType.NestedB"
+		if value := monikers[0].Identifier; value != expectedIdentifier {
+			t.Errorf("incorrect identifier. want=%q have=%q", expectedIdentifier, value)
+		}
+	})
 }
 
 func compareRange(t *testing.T, r *protocol.Range, startLine, startCharacter, endLine, endCharacter int) {

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -5,7 +5,6 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/sourcegraph/lsif-go/internal/writer"
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 
@@ -19,7 +18,7 @@ func TestIndexer(t *testing.T) {
 		"testdata",
 		"0.0.1",
 		nil,
-		writer.NewEmitter(w),
+		w,
 		false,
 	)
 

--- a/internal/indexer/info.go
+++ b/internal/indexer/info.go
@@ -10,10 +10,10 @@ import (
 
 // Stats summarizes the amount of work done by the indexer.
 type Stats struct {
-	NumPkgs     int
-	NumFiles    int
-	NumDefs     int
-	NumElements int
+	NumPkgs     uint
+	NumFiles    uint
+	NumDefs     uint
+	NumElements uint64
 }
 
 // FileInfo provides context about a particular file.
@@ -27,9 +27,9 @@ type FileInfo struct {
 // DocumentInfo provides context for constructing the contains relationship between
 // a document and the ranges that it contains.
 type DocumentInfo struct {
-	DocumentID         string
-	DefinitionRangeIDs []string
-	ReferenceRangeIDs  []string
+	DocumentID         uint64
+	DefinitionRangeIDs []uint64
+	ReferenceRangeIDs  []uint64
 }
 
 // ObjectInfo provides context about a particular object within a file.
@@ -44,15 +44,15 @@ type ObjectInfo struct {
 // of this shape is keyed by type and identifier in the indexer so that it can be
 // re-retrieved for a range that uses the definition.
 type DefinitionInfo struct {
-	DocumentID  string
-	RangeID     string
-	ResultSetID string
+	DocumentID  uint64
+	RangeID     uint64
+	ResultSetID uint64
 }
 
 // ReferenceResultInfo provides context about a definition range. Each definition and
 // reference range will be added to an object of this shape as it is processed.
 type ReferenceResultInfo struct {
-	ResultSetID        string
-	DefinitionRangeIDs map[string][]string
-	ReferenceRangeIDs  map[string][]string
+	ResultSetID        uint64
+	DefinitionRangeIDs map[uint64][]uint64
+	ReferenceRangeIDs  map[uint64][]uint64
 }

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -13,7 +13,7 @@ import (
 // emitExportMoniker emits an export moniker for the given object linked to the given source
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the current module.
-func (i *Indexer) emitExportMoniker(sourceID string, o ObjectInfo) error {
+func (i *Indexer) emitExportMoniker(sourceID uint64, o ObjectInfo) error {
 	if i.moduleName == "" {
 		// Unknown dependencies, skip export monikers
 		return nil
@@ -31,7 +31,7 @@ func (i *Indexer) emitExportMoniker(sourceID string, o ObjectInfo) error {
 // identifier (either a range or a result set identifier). This will also emit links between
 // the moniker vertex and the package information vertex representing the dependency containing
 // the identifier.
-func (i *Indexer) emitImportMoniker(sourceID string, o ObjectInfo) error {
+func (i *Indexer) emitImportMoniker(sourceID uint64, o ObjectInfo) error {
 	pkg := monikerPackage(o)
 
 	for _, moduleName := range packagePrefixes(pkg) {
@@ -67,11 +67,11 @@ func packagePrefixes(packageName string) []string {
 // ensurePackageInformation returns the identifier of a package information vertex with the
 // give name and version. A vertex will be emitted only if one with the same name not yet
 // been emitted.
-func (i *Indexer) ensurePackageInformation(name, version string) (_ string, err error) {
+func (i *Indexer) ensurePackageInformation(name, version string) (_ uint64, err error) {
 	packageInformationID, ok := i.packageInformationIDs[name]
 	if !ok {
 		if packageInformationID, err = i.emitter.EmitPackageInformation(name, "gomod", version); err != nil {
-			return "", errors.Wrap(err, "writer.EmitPackageInformation")
+			return 0, errors.Wrap(err, "writer.EmitPackageInformation")
 		}
 
 		i.packageInformationIDs[name] = packageInformationID
@@ -83,7 +83,7 @@ func (i *Indexer) ensurePackageInformation(name, version string) (_ string, err 
 // addMonikers emits a moniker vertex with the given identifier, an edge from the moniker
 // to the given package information vertex identifier, and an edge from the given source
 // identifier to the moniker vertex identifier.
-func (i *Indexer) addMonikers(kind, identifier, sourceID, packageID string) error {
+func (i *Indexer) addMonikers(kind, identifier string, sourceID, packageID uint64) error {
 	monikerID, err := i.emitter.EmitMoniker(kind, "gomod", identifier)
 	if err != nil {
 		return errors.Wrap(err, "writer.EmitMoniker")

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -2,11 +2,8 @@ package indexer
 
 import (
 	"fmt"
-	"go/ast"
 	"go/types"
 	"strings"
-
-	"golang.org/x/tools/go/ast/astutil"
 )
 
 // emitExportMoniker emits an export moniker for the given object linked to the given source
@@ -20,7 +17,7 @@ func (i *Indexer) emitExportMoniker(sourceID uint64, o ObjectInfo) {
 
 	i.addMonikers(
 		"export",
-		strings.Trim(fmt.Sprintf("%s:%s", monikerPackage(o), monikerIdentifier(o)), ":"),
+		strings.Trim(fmt.Sprintf("%s:%s", monikerPackage(o), monikerIdentifier(i.hoverLoader, o)), ":"),
 		sourceID,
 		i.ensurePackageInformation(i.moduleName, i.moduleVersion),
 	)
@@ -37,7 +34,7 @@ func (i *Indexer) emitImportMoniker(sourceID uint64, o ObjectInfo) {
 		if moduleVersion, ok := i.dependencies[moduleName]; ok {
 			i.addMonikers(
 				"import",
-				strings.Trim(fmt.Sprintf("%s:%s", pkg, monikerIdentifier(o)), ":"),
+				strings.Trim(fmt.Sprintf("%s:%s", pkg, monikerIdentifier(i.hoverLoader, o)), ":"),
 				sourceID,
 				i.ensurePackageInformation(moduleName, moduleVersion),
 			)
@@ -95,49 +92,28 @@ func monikerPackage(o ObjectInfo) string {
 // monikerIdentifier returns the identifier suffix used to construct a unique moniker for the given object.
 // A full moniker has the form `{package prefix}:{identifier suffix}`. The identifier is meant to act as a
 // qualified type path to the given object (e.g. `StructName.FieldName` or `StructName.MethodName`).
-func monikerIdentifier(o ObjectInfo) string {
+func monikerIdentifier(hoverLoader *HoverLoader, o ObjectInfo) string {
 	if _, ok := o.Object.(*types.PkgName); ok {
 		// Packages are identified uniquely by their package prefix
 		return ""
 	}
 
-	return strings.Join(append(monikerIdentifierQualifiers(o), o.Ident.String()), ".")
-}
-
-// monikerIdentifierQualifiers returns a slice of container names used to construct the moniker identifier
-// uniquely defining the given object. This will include the names of structs, interfaces, and receivers
-// enclosing the target field or signature.
-func monikerIdentifierQualifiers(o ObjectInfo) (qualifiers []string) {
 	if v, ok := o.Object.(*types.Var); ok && v.IsField() {
-		// TODO(efritz) - investigate performance of this function
-		// Get path of nodes from the file root to the var identifier
-		path, _ := astutil.PathEnclosingInterval(o.File, o.Ident.Pos(), o.Ident.Pos())
-
-		// walk the nodes inside-out (from target to file root) and add the name of
-		// each container to the list of qualifiers.
-		for i := len(path) - 1; i >= 0; i-- {
-			switch q := path[i].(type) {
-			case *ast.Field:
-				if q.Pos() != v.Pos() {
-					// Add names of distinct fields whose type is an anonymous struct type
-					// containing the target field (e.g. `X struct { target string }`).
-					qualifiers = append(qualifiers, q.Names[0].String())
-				}
-
-			case *ast.TypeSpec:
-				// Add the top-level type spec (e.g. `type X struct` and `type Y interface`)
-				qualifiers = append(qualifiers, q.Name.String())
-			}
-		}
-
+		// Qualifiers for fields were populated as pre-load step so we do not need to traverse
+		// the AST path back up to the root to find the enclosing type specs and fields with an
+		// anonymous struct type.
+		return strings.Join(hoverLoader.MonikerPath(o.File, o.Object.Pos()), ".")
 	}
 
 	if signature, ok := o.Object.Type().(*types.Signature); ok {
 		if recv := signature.Recv(); recv != nil {
-			// Qualify function with receiver stripped of a pointer indicator `*` and its package path
-			qualifiers = append(qualifiers, strings.TrimPrefix(strings.TrimPrefix(recv.Type().String(), "*"), o.Object.Pkg().Path()+"."))
+			return strings.Join([]string{
+				// Qualify function with receiver stripped of a pointer indicator `*` and its package path
+				strings.TrimPrefix(strings.TrimPrefix(recv.Type().String(), "*"), o.Object.Pkg().Path()+"."),
+				o.Ident.String(),
+			}, ".")
 		}
 	}
 
-	return qualifiers
+	return o.Ident.String()
 }

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -17,7 +17,7 @@ func (i *Indexer) emitExportMoniker(sourceID uint64, o ObjectInfo) {
 
 	i.addMonikers(
 		"export",
-		strings.Trim(fmt.Sprintf("%s:%s", monikerPackage(o), monikerIdentifier(i.hoverLoader, o)), ":"),
+		strings.Trim(fmt.Sprintf("%s:%s", monikerPackage(o), monikerIdentifier(i.preloader, o)), ":"),
 		sourceID,
 		i.ensurePackageInformation(i.moduleName, i.moduleVersion),
 	)
@@ -34,7 +34,7 @@ func (i *Indexer) emitImportMoniker(sourceID uint64, o ObjectInfo) {
 		if moduleVersion, ok := i.dependencies[moduleName]; ok {
 			i.addMonikers(
 				"import",
-				strings.Trim(fmt.Sprintf("%s:%s", pkg, monikerIdentifier(i.hoverLoader, o)), ":"),
+				strings.Trim(fmt.Sprintf("%s:%s", pkg, monikerIdentifier(i.preloader, o)), ":"),
 				sourceID,
 				i.ensurePackageInformation(moduleName, moduleVersion),
 			)
@@ -92,7 +92,7 @@ func monikerPackage(o ObjectInfo) string {
 // monikerIdentifier returns the identifier suffix used to construct a unique moniker for the given object.
 // A full moniker has the form `{package prefix}:{identifier suffix}`. The identifier is meant to act as a
 // qualified type path to the given object (e.g. `StructName.FieldName` or `StructName.MethodName`).
-func monikerIdentifier(hoverLoader *HoverLoader, o ObjectInfo) string {
+func monikerIdentifier(preloader *Preloader, o ObjectInfo) string {
 	if _, ok := o.Object.(*types.PkgName); ok {
 		// Packages are identified uniquely by their package prefix
 		return ""
@@ -102,7 +102,7 @@ func monikerIdentifier(hoverLoader *HoverLoader, o ObjectInfo) string {
 		// Qualifiers for fields were populated as pre-load step so we do not need to traverse
 		// the AST path back up to the root to find the enclosing type specs and fields with an
 		// anonymous struct type.
-		return strings.Join(hoverLoader.MonikerPath(o.File, o.Object.Pos()), ".")
+		return strings.Join(preloader.MonikerPath(o.File, o.Object.Pos()), ".")
 	}
 
 	if signature, ok := o.Object.Type().(*types.Signature); ok {

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -29,12 +29,10 @@ func TestEmitExportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitExportMoniker(123, ObjectInfo{
+	indexer.emitExportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
-	}); err != nil {
-		t.Fatalf("unexpected error emitting moniker: %s", err)
-	}
+	})
 
 	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
@@ -81,12 +79,10 @@ func TestEmitImportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitImportMoniker(123, ObjectInfo{
+	indexer.emitImportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
-	}); err != nil {
-		t.Fatalf("unexpected error emitting moniker: %s", err)
-	}
+	})
 
 	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -18,7 +18,7 @@ func TestEmitExportMoniker(t *testing.T) {
 		moduleName:            "github.com/sourcegraph/lsif-go",
 		moduleVersion:         "3.14.159",
 		emitter:               writer.NewEmitter(w),
-		packageInformationIDs: map[string]string{},
+		packageInformationIDs: map[string]uint64{},
 	}
 
 	object := types.NewConst(
@@ -29,14 +29,14 @@ func TestEmitExportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitExportMoniker("123", ObjectInfo{
+	if err := indexer.emitExportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
 	}); err != nil {
 		t.Fatalf("unexpected error emitting moniker: %s", err)
 	}
 
-	monikers := findMonikersByRangeOrReferenceResultID(w.elements, "123")
+	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
 		t.Fatalf("could not find moniker")
 	}
@@ -70,7 +70,7 @@ func TestEmitImportMoniker(t *testing.T) {
 			"github.com/test/pkg/sub1": "1.2.3-deadbeef",
 		},
 		emitter:               writer.NewEmitter(w),
-		packageInformationIDs: map[string]string{},
+		packageInformationIDs: map[string]uint64{},
 	}
 
 	object := types.NewConst(
@@ -81,14 +81,14 @@ func TestEmitImportMoniker(t *testing.T) {
 		constant.MakeBool(true),
 	)
 
-	if err := indexer.emitImportMoniker("123", ObjectInfo{
+	if err := indexer.emitImportMoniker(123, ObjectInfo{
 		Ident:  &ast.Ident{Name: "foobar"},
 		Object: object,
 	}); err != nil {
 		t.Fatalf("unexpected error emitting moniker: %s", err)
 	}
 
-	monikers := findMonikersByRangeOrReferenceResultID(w.elements, "123")
+	monikers := findMonikersByRangeOrReferenceResultID(w.elements, 123)
 	if monikers == nil || len(monikers) < 1 {
 		t.Fatalf("could not find moniker")
 	}

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -127,25 +127,33 @@ func TestPackagePrefixes(t *testing.T) {
 }
 
 func TestMonikerIdentifierBasic(t *testing.T) {
-	if identifier := monikerIdentifier(findObjectInfoByDefinitionName(t, "Score")); identifier != "Score" {
+	packages, o := findObjectInfoByUseName(t, "Score")
+
+	if identifier := monikerIdentifier(preload(packages), o); identifier != "Score" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "Score", identifier)
 	}
 }
 
 func TestMonikerIdentifierPackageName(t *testing.T) {
-	if identifier := monikerIdentifier(findObjectInfoByUseName(t, "sync")); identifier != "" {
+	packages, o := findObjectInfoByUseName(t, "sync")
+
+	if identifier := monikerIdentifier(preload(packages), o); identifier != "" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "", identifier)
 	}
 }
 
 func TestMonikerIdentifierSignature(t *testing.T) {
-	if identifier := monikerIdentifier(findObjectInfoByDefinitionName(t, "Doer")); identifier != "TestStruct.Doer" {
+	packages, o := findObjectInfoByDefinitionName(t, "Doer")
+
+	if identifier := monikerIdentifier(preload(packages), o); identifier != "TestStruct.Doer" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "TestStruct.Doer", identifier)
 	}
 }
 
 func TestMonikerIdentifierField(t *testing.T) {
-	if identifier := monikerIdentifier(findObjectInfoByDefinitionName(t, "NestedB")); identifier != "TestStruct.FieldWithAnonymousType.NestedB" {
+	packages, o := findObjectInfoByDefinitionName(t, "NestedB")
+
+	if identifier := monikerIdentifier(preload(packages), o); identifier != "TestStruct.FieldWithAnonymousType.NestedB" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "TestStruct.FieldWithAnonymousType.NestedB", identifier)
 	}
 }

--- a/internal/indexer/preloader_test.go
+++ b/internal/indexer/preloader_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 )
 
-func TestHoverLoader(t *testing.T) {
+func TestPreloader(t *testing.T) {
 	packages := getTestPackages(t)
-	hoverLoader := loadHovers(packages)
+	preloader := preload(packages)
 	p, target := findDefinitionByName(t, packages, "ParallelizableFunc")
 
 	expectedText := normalizeDocstring(`
@@ -17,7 +17,7 @@ func TestHoverLoader(t *testing.T) {
 
 	t.Run("Text", func(t *testing.T) {
 		for _, f := range p.Syntax {
-			if text := normalizeDocstring(hoverLoader.Text(f, target.Pos())); text != "" {
+			if text := normalizeDocstring(preloader.Text(f, target.Pos())); text != "" {
 				if text != expectedText {
 					t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 				}
@@ -30,7 +30,7 @@ func TestHoverLoader(t *testing.T) {
 	})
 
 	t.Run("TextFromPackage", func(t *testing.T) {
-		if text := normalizeDocstring(hoverLoader.TextFromPackage(p, target.Pos())); text != expectedText {
+		if text := normalizeDocstring(preloader.TextFromPackage(p, target.Pos())); text != expectedText {
 			t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 		}
 	})

--- a/internal/indexer/util.go
+++ b/internal/indexer/util.go
@@ -1,8 +1,8 @@
 package indexer
 
-// union concatenates, flattens, and deduplicates the given string slices.
-func union(as ...[]string) (flattened []string) {
-	m := map[string]struct{}{}
+// union concatenates, flattens, and deduplicates the given identifier slices.
+func union(as ...[]uint64) (flattened []uint64) {
+	m := map[uint64]struct{}{}
 	for _, a := range as {
 		for _, v := range a {
 			m[v] = struct{}{}

--- a/internal/indexer/util_test.go
+++ b/internal/indexer/util_test.go
@@ -9,14 +9,18 @@ import (
 
 func TestUnion(t *testing.T) {
 	u := union(
-		[]string{"a1", "a2", "a3"},
-		[]string{"b1", "b2", "b3"},
-		[]string{"a1", "b2", "c3"},
+		[]uint64{10, 20, 30},
+		[]uint64{100, 200, 300},
+		[]uint64{10, 200, 3000},
 	)
-	sort.Strings(u)
+	sort.Slice(u, func(i, j int) bool {
+		return u[i] < u[j]
+	})
 
-	expected := []string{
-		"a1", "a2", "a3", "b1", "b2", "b3", "c3",
+	expected := []uint64{
+		10, 20, 30,
+		100, 200, 300,
+		3000,
 	}
 
 	if diff := cmp.Diff(expected, u); diff != "" {

--- a/internal/indexer/visit.go
+++ b/internal/indexer/visit.go
@@ -5,21 +5,21 @@ import "github.com/efritz/pentimento"
 // visitEachRawFile invokes the given visitor function on each file reachable from the given set of
 // packages. The file info object passed to the given callback function does not have an associated
 // document value. This method prints the progress of the traversal to stdout asynchronously.
-func (i *Indexer) visitEachRawFile(name string, animate bool, fn func(f FileInfo) error) error {
+func (i *Indexer) visitEachRawFile(name string, animate bool, fn func(f FileInfo)) {
 	n := 0
 	for _, p := range i.packages {
 		n += len(p.Syntax)
 	}
 
-	return withTitle(name, animate, func(printer *pentimento.Printer) error {
+	_ = withTitle(name, animate, func(printer *pentimento.Printer) error {
 		c := 0
 		for _, p := range i.packages {
 			for _, f := range p.Syntax {
-				filename := p.Fset.Position(f.Package).Filename
-
-				if err := fn(FileInfo{Package: p, File: f, Filename: filename}); err != nil {
-					return err
-				}
+				fn(FileInfo{
+					Package:  p,
+					File:     f,
+					Filename: p.Fset.Position(f.Package).Filename,
+				})
 
 				c++
 				printProgress(printer, name, c, n)
@@ -33,8 +33,8 @@ func (i *Indexer) visitEachRawFile(name string, animate bool, fn func(f FileInfo
 // visitEachFile invokes the given visitor function on each file reachable from the given set of packages that
 // also has an entry in the indexer's files map. This method prints the progress of the traversal to stdout
 // asynchronously.
-func (i *Indexer) visitEachFile(name string, animate bool, fn func(f FileInfo) error) error {
-	return withTitle(name, animate, func(printer *pentimento.Printer) error {
+func (i *Indexer) visitEachFile(name string, animate bool, fn func(f FileInfo)) {
+	_ = withTitle(name, animate, func(printer *pentimento.Printer) error {
 		processed := map[string]bool{}
 
 		c := 0
@@ -51,9 +51,12 @@ func (i *Indexer) visitEachFile(name string, animate bool, fn func(f FileInfo) e
 					continue
 				}
 
-				if err := fn(FileInfo{Package: p, File: f, Filename: filename, Document: d}); err != nil {
-					return err
-				}
+				fn(FileInfo{
+					Package:  p,
+					File:     f,
+					Filename: filename,
+					Document: d,
+				})
 
 				c++
 				printProgress(printer, name, c, len(i.documents))

--- a/internal/writer/emitter.go
+++ b/internal/writer/emitter.go
@@ -1,8 +1,6 @@
 package writer
 
 import (
-	"strconv"
-
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 
@@ -10,9 +8,8 @@ import (
 // JSONWriter instance. Use of this struct guarantees that unique identifiers
 // are generated for each constructed element.
 type Emitter struct {
-	writer      JSONWriter
-	id          int
-	numElements int
+	writer JSONWriter
+	id     uint64
 }
 
 func NewEmitter(writer JSONWriter) *Emitter {
@@ -21,126 +18,121 @@ func NewEmitter(writer JSONWriter) *Emitter {
 	}
 }
 
-func (e *Emitter) NumElements() int {
-	return e.numElements
+func (e *Emitter) NumElements() uint64 {
+	return e.id
 }
 
-func (e *Emitter) NextID() string {
+func (e *Emitter) NextID() uint64 {
 	e.id++
-	return strconv.Itoa(e.id)
+	return e.id
 }
 
-func (e *Emitter) emit(v interface{}) error {
-	e.numElements++
-	return e.writer.Write(v)
-}
-
-func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (string, error) {
+func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewMetaData(id, root, info))
+	return id, e.writer.Write(protocol.NewMetaData(id, root, info))
 }
 
-func (e *Emitter) EmitProject(languageID string) (string, error) {
+func (e *Emitter) EmitProject(languageID string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewProject(id, languageID))
+	return id, e.writer.Write(protocol.NewProject(id, languageID))
 }
 
-func (e *Emitter) EmitDocument(languageID, path string) (string, error) {
+func (e *Emitter) EmitDocument(languageID, path string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewDocument(id, languageID, "file://"+path, nil))
+	return id, e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path, nil))
 }
 
-func (e *Emitter) EmitRange(start, end protocol.Pos) (string, error) {
+func (e *Emitter) EmitRange(start, end protocol.Pos) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewRange(id, start, end))
+	return id, e.writer.Write(protocol.NewRange(id, start, end))
 }
 
-func (e *Emitter) EmitResultSet() (string, error) {
+func (e *Emitter) EmitResultSet() (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewResultSet(id))
+	return id, e.writer.Write(protocol.NewResultSet(id))
 }
 
-func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (string, error) {
+func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewHoverResult(id, contents))
+	return id, e.writer.Write(protocol.NewHoverResult(id, contents))
 }
 
-func (e *Emitter) EmitTextDocumentHover(outV, inV string) (string, error) {
+func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewTextDocumentHover(id, outV, inV))
+	return id, e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
 }
 
-func (e *Emitter) EmitDefinitionResult() (string, error) {
+func (e *Emitter) EmitDefinitionResult() (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewDefinitionResult(id))
+	return id, e.writer.Write(protocol.NewDefinitionResult(id))
 }
 
-func (e *Emitter) EmitTextDocumentDefinition(outV, inV string) (string, error) {
+func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewTextDocumentDefinition(id, outV, inV))
+	return id, e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
 }
 
-func (e *Emitter) EmitReferenceResult() (string, error) {
+func (e *Emitter) EmitReferenceResult() (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewReferenceResult(id))
+	return id, e.writer.Write(protocol.NewReferenceResult(id))
 }
 
-func (e *Emitter) EmitTextDocumentReferences(outV, inV string) (string, error) {
+func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewTextDocumentReferences(id, outV, inV))
+	return id, e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
 }
 
-func (e *Emitter) EmitItem(outV string, inVs []string, docID string) (string, error) {
+func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewItem(id, outV, inVs, docID))
+	return id, e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitItemOfDefinitions(outV string, inVs []string, docID string) (string, error) {
+func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
+	return id, e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitItemOfReferences(outV string, inVs []string, docID string) (string, error) {
+func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewItemOfReferences(id, outV, inVs, docID))
+	return id, e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
 }
 
-func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (string, error) {
+func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewMoniker(id, kind, scheme, identifier))
+	return id, e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
 }
 
-func (e *Emitter) EmitMonikerEdge(outV, inV string) (string, error) {
+func (e *Emitter) EmitMonikerEdge(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewMonikerEdge(id, outV, inV))
+	return id, e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
 }
 
-func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (string, error) {
+func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewPackageInformation(id, packageName, scheme, version))
+	return id, e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
 }
 
-func (e *Emitter) EmitPackageInformationEdge(outV, inV string) (string, error) {
+func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewPackageInformationEdge(id, outV, inV))
+	return id, e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
 }
 
-func (e *Emitter) EmitContains(outV string, inVs []string) (string, error) {
+func (e *Emitter) EmitContains(outV uint64, inVs []uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewContains(id, outV, inVs))
+	return id, e.writer.Write(protocol.NewContains(id, outV, inVs))
 }
 
-func (e *Emitter) EmitNext(outV, inV string) (string, error) {
+func (e *Emitter) EmitNext(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewNext(id, outV, inV))
+	return id, e.writer.Write(protocol.NewNext(id, outV, inV))
 }
 
-func (e *Emitter) EmitBeginEvent(scope string, data string) (string, error) {
+func (e *Emitter) EmitBeginEvent(scope string, data string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewEvent(id, "begin", scope, data))
+	return id, e.writer.Write(protocol.NewEvent(id, "begin", scope, data))
 }
 
-func (e *Emitter) EmitEndEvent(scope string, data string) (string, error) {
+func (e *Emitter) EmitEndEvent(scope string, data string) (uint64, error) {
 	id := e.NextID()
-	return id, e.emit(protocol.NewEvent(id, "end", scope, data))
+	return id, e.writer.Write(protocol.NewEvent(id, "end", scope, data))
 }

--- a/internal/writer/emitter.go
+++ b/internal/writer/emitter.go
@@ -20,146 +20,146 @@ func NewEmitter(writer JSONWriter) *Emitter {
 	}
 }
 
-func (e *Emitter) NumElements() uint64 {
-	return atomic.LoadUint64(&e.id)
+func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewMetaData(id, root, info))
+	return id
 }
 
-func (e *Emitter) NextID() uint64 {
-	return atomic.AddUint64(&e.id, 1)
+func (e *Emitter) EmitProject(languageID string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewProject(id, languageID))
+	return id
+}
+
+func (e *Emitter) EmitDocument(languageID, path string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path, nil))
+	return id
+}
+
+func (e *Emitter) EmitRange(start, end protocol.Pos) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewRange(id, start, end))
+	return id
+}
+
+func (e *Emitter) EmitResultSet() uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewResultSet(id))
+	return id
+}
+
+func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewHoverResult(id, contents))
+	return id
+}
+
+func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitDefinitionResult() uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewDefinitionResult(id))
+	return id
+}
+
+func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitReferenceResult() uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewReferenceResult(id))
+	return id
+}
+
+func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
+	return id
+}
+
+func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
+	return id
+}
+
+func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
+	return id
+}
+
+func (e *Emitter) EmitMoniker(kind, scheme, identifier string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
+	return id
+}
+
+func (e *Emitter) EmitMonikerEdge(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
+	return id
+}
+
+func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitContains(outV uint64, inVs []uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewContains(id, outV, inVs))
+	return id
+}
+
+func (e *Emitter) EmitNext(outV, inV uint64) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewNext(id, outV, inV))
+	return id
+}
+
+func (e *Emitter) EmitBeginEvent(scope string, data string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewEvent(id, "begin", scope, data))
+	return id
+}
+
+func (e *Emitter) EmitEndEvent(scope string, data string) uint64 {
+	id := e.nextID()
+	e.writer.Write(protocol.NewEvent(id, "end", scope, data))
+	return id
+}
+
+func (e *Emitter) NumElements() uint64 {
+	return atomic.LoadUint64(&e.id)
 }
 
 func (e *Emitter) Flush() error {
 	return e.writer.Flush()
 }
 
-func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewMetaData(id, root, info))
-	return id, nil
-}
-
-func (e *Emitter) EmitProject(languageID string) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewProject(id, languageID))
-	return id, nil
-}
-
-func (e *Emitter) EmitDocument(languageID, path string) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path, nil))
-	return id, nil
-}
-
-func (e *Emitter) EmitRange(start, end protocol.Pos) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewRange(id, start, end))
-	return id, nil
-}
-
-func (e *Emitter) EmitResultSet() (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewResultSet(id))
-	return id, nil
-}
-
-func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewHoverResult(id, contents))
-	return id, nil
-}
-
-func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
-	return id, nil
-}
-
-func (e *Emitter) EmitDefinitionResult() (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewDefinitionResult(id))
-	return id, nil
-}
-
-func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
-	return id, nil
-}
-
-func (e *Emitter) EmitReferenceResult() (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewReferenceResult(id))
-	return id, nil
-}
-
-func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
-	return id, nil
-}
-
-func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
-	return id, nil
-}
-
-func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
-	return id, nil
-}
-
-func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
-	return id, nil
-}
-
-func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
-	return id, nil
-}
-
-func (e *Emitter) EmitMonikerEdge(outV, inV uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
-	return id, nil
-}
-
-func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
-	return id, nil
-}
-
-func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
-	return id, nil
-}
-
-func (e *Emitter) EmitContains(outV uint64, inVs []uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewContains(id, outV, inVs))
-	return id, nil
-}
-
-func (e *Emitter) EmitNext(outV, inV uint64) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewNext(id, outV, inV))
-	return id, nil
-}
-
-func (e *Emitter) EmitBeginEvent(scope string, data string) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewEvent(id, "begin", scope, data))
-	return id, nil
-}
-
-func (e *Emitter) EmitEndEvent(scope string, data string) (uint64, error) {
-	id := e.NextID()
-	e.writer.Write(protocol.NewEvent(id, "end", scope, data))
-	return id, nil
+func (e *Emitter) nextID() uint64 {
+	return atomic.AddUint64(&e.id, 1)
 }

--- a/internal/writer/emitter.go
+++ b/internal/writer/emitter.go
@@ -1,6 +1,8 @@
 package writer
 
 import (
+	"sync/atomic"
+
 	"github.com/sourcegraph/lsif-go/protocol"
 )
 
@@ -19,120 +21,145 @@ func NewEmitter(writer JSONWriter) *Emitter {
 }
 
 func (e *Emitter) NumElements() uint64 {
-	return e.id
+	return atomic.LoadUint64(&e.id)
 }
 
 func (e *Emitter) NextID() uint64 {
-	e.id++
-	return e.id
+	return atomic.AddUint64(&e.id, 1)
+}
+
+func (e *Emitter) Flush() error {
+	return e.writer.Flush()
 }
 
 func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewMetaData(id, root, info))
+	e.writer.Write(protocol.NewMetaData(id, root, info))
+	return id, nil
 }
 
 func (e *Emitter) EmitProject(languageID string) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewProject(id, languageID))
+	e.writer.Write(protocol.NewProject(id, languageID))
+	return id, nil
 }
 
 func (e *Emitter) EmitDocument(languageID, path string) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path, nil))
+	e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path, nil))
+	return id, nil
 }
 
 func (e *Emitter) EmitRange(start, end protocol.Pos) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewRange(id, start, end))
+	e.writer.Write(protocol.NewRange(id, start, end))
+	return id, nil
 }
 
 func (e *Emitter) EmitResultSet() (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewResultSet(id))
+	e.writer.Write(protocol.NewResultSet(id))
+	return id, nil
 }
 
 func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewHoverResult(id, contents))
+	e.writer.Write(protocol.NewHoverResult(id, contents))
+	return id, nil
 }
 
 func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
+	e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
+	return id, nil
 }
 
 func (e *Emitter) EmitDefinitionResult() (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewDefinitionResult(id))
+	e.writer.Write(protocol.NewDefinitionResult(id))
+	return id, nil
 }
 
 func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
+	e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
+	return id, nil
 }
 
 func (e *Emitter) EmitReferenceResult() (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewReferenceResult(id))
+	e.writer.Write(protocol.NewReferenceResult(id))
+	return id, nil
 }
 
 func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
+	e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
+	return id, nil
 }
 
 func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
+	e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
+	return id, nil
 }
 
 func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
+	e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
+	return id, nil
 }
 
 func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
+	e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
+	return id, nil
 }
 
 func (e *Emitter) EmitMoniker(kind, scheme, identifier string) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
+	e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
+	return id, nil
 }
 
 func (e *Emitter) EmitMonikerEdge(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
+	e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
+	return id, nil
 }
 
 func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
+	e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
+	return id, nil
 }
 
 func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
+	e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
+	return id, nil
 }
 
 func (e *Emitter) EmitContains(outV uint64, inVs []uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewContains(id, outV, inVs))
+	e.writer.Write(protocol.NewContains(id, outV, inVs))
+	return id, nil
 }
 
 func (e *Emitter) EmitNext(outV, inV uint64) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewNext(id, outV, inV))
+	e.writer.Write(protocol.NewNext(id, outV, inV))
+	return id, nil
 }
 
 func (e *Emitter) EmitBeginEvent(scope string, data string) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewEvent(id, "begin", scope, data))
+	e.writer.Write(protocol.NewEvent(id, "begin", scope, data))
+	return id, nil
 }
 
 func (e *Emitter) EmitEndEvent(scope string, data string) (uint64, error) {
 	id := e.NextID()
-	return id, e.writer.Write(protocol.NewEvent(id, "end", scope, data))
+	e.writer.Write(protocol.NewEvent(id, "end", scope, data))
+	return id, nil
 }

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -1,27 +1,65 @@
 package writer
 
 import (
-	"encoding/json"
 	"io"
+	"sync"
+
+	jsoniter "github.com/json-iterator/go"
 )
+
+var marshaller = jsoniter.ConfigFastest
 
 // JSONWriter serializes vertexes and edges into JSON and writes them to an
 // underlying writer as newline-delimited JSON.
 type JSONWriter interface {
 	// Write emits a single vertex or edge value.
-	Write(v interface{}) error
+	Write(v interface{})
+
+	// Flush ensures that all elements have been written to the underlying writer.
+	Flush() error
 }
 
 type jsonWriter struct {
-	w io.Writer
+	wg  sync.WaitGroup
+	ch  chan (interface{})
+	err error
 }
+
+// channelBufferSize is the nubmer of elements that can be queued to be written.
+const channelBufferSize = 512
 
 // NewJSONWriter creates a new JSONWriter wrapping the given writer.
 func NewJSONWriter(w io.Writer) JSONWriter {
-	return &jsonWriter{w}
+	ch := make(chan interface{}, channelBufferSize)
+	jw := &jsonWriter{ch: ch}
+	encoder := marshaller.NewEncoder(w)
+
+	jw.wg.Add(1)
+	go func() {
+		defer jw.wg.Done()
+
+		for v := range ch {
+			if err := encoder.Encode(v); err != nil {
+				jw.err = err
+				break
+			}
+		}
+
+		for range ch {
+		}
+	}()
+
+	return jw
 }
 
 // Write emits a single vertex or edge value.
-func (w *jsonWriter) Write(v interface{}) error {
-	return json.NewEncoder(w.w).Encode(v)
+func (jw *jsonWriter) Write(v interface{}) {
+	jw.ch <- v
+}
+
+// Flush ensures that all elements have been written to the underlying writer.
+func (jw *jsonWriter) Flush() error {
+	close(jw.ch)
+	jw.wg.Wait()
+	return jw.err
 }

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -1,6 +1,7 @@
 package writer
 
 import (
+	"bufio"
 	"io"
 	"sync"
 
@@ -25,14 +26,17 @@ type jsonWriter struct {
 	err error
 }
 
-// channelBufferSize is the nubmer of elements that can be queued to be written.
+// channelBufferSize is the number of elements that can be queued to be written.
 const channelBufferSize = 512
+
+// writerBufferSize is the size of the buffered writer wrapping output to the target file.
+const writerBufferSize = 4096
 
 // NewJSONWriter creates a new JSONWriter wrapping the given writer.
 func NewJSONWriter(w io.Writer) JSONWriter {
 	ch := make(chan interface{}, channelBufferSize)
 	jw := &jsonWriter{ch: ch}
-	encoder := marshaller.NewEncoder(w)
+	encoder := marshaller.NewEncoder(bufio.NewWriterSize(w, writerBufferSize))
 
 	jw.wg.Add(1)
 	go func() {

--- a/protocol/contains.go
+++ b/protocol/contains.go
@@ -2,11 +2,11 @@ package protocol
 
 type Contains struct {
 	Edge
-	OutV string   `json:"outV"`
-	InVs []string `json:"inVs"`
+	OutV uint64   `json:"outV"`
+	InVs []uint64 `json:"inVs"`
 }
 
-func NewContains(id, outV string, inVs []string) *Contains {
+func NewContains(id, outV uint64, inVs []uint64) *Contains {
 	return &Contains{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/definition.go
+++ b/protocol/definition.go
@@ -4,7 +4,7 @@ type DefinitionResult struct {
 	Vertex
 }
 
-func NewDefinitionResult(id string) *DefinitionResult {
+func NewDefinitionResult(id uint64) *DefinitionResult {
 	return &DefinitionResult{
 		Vertex: Vertex{
 			Element: Element{
@@ -18,11 +18,11 @@ func NewDefinitionResult(id string) *DefinitionResult {
 
 type TextDocumentDefinition struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentDefinition(id, outV, inV string) *TextDocumentDefinition {
+func NewTextDocumentDefinition(id, outV, inV uint64) *TextDocumentDefinition {
 	return &TextDocumentDefinition{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/document.go
+++ b/protocol/document.go
@@ -9,7 +9,7 @@ type Document struct {
 	Contents   string `json:"contents,omitempty"`
 }
 
-func NewDocument(id, languageID, uri string, contents []byte) *Document {
+func NewDocument(id uint64, languageID, uri string, contents []byte) *Document {
 	d := &Document{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/element.go
+++ b/protocol/element.go
@@ -1,7 +1,7 @@
 package protocol
 
 type Element struct {
-	ID   string      `json:"id"`
+	ID   uint64      `json:"id"`
 	Type ElementType `json:"type"`
 }
 

--- a/protocol/event.go
+++ b/protocol/event.go
@@ -7,7 +7,7 @@ type Event struct {
 	Data  string `json:"data"`
 }
 
-func NewEvent(id, kind, scope, data string) *Event {
+func NewEvent(id uint64, kind, scope, data string) *Event {
 	return &Event{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/hover.go
+++ b/protocol/hover.go
@@ -11,7 +11,7 @@ type hoverResult struct {
 	Contents []MarkedString `json:"contents"`
 }
 
-func NewHoverResult(id string, contents []MarkedString) *HoverResult {
+func NewHoverResult(id uint64, contents []MarkedString) *HoverResult {
 	return &HoverResult{
 		Vertex: Vertex{
 			Element: Element{
@@ -57,11 +57,11 @@ func (m MarkedString) MarshalJSON() ([]byte, error) {
 
 type TextDocumentHover struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentHover(id, outV, inV string) *TextDocumentHover {
+func NewTextDocumentHover(id, outV, inV uint64) *TextDocumentHover {
 	return &TextDocumentHover{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/item.go
+++ b/protocol/item.go
@@ -2,13 +2,13 @@ package protocol
 
 type Item struct {
 	Edge
-	OutV     string   `json:"outV"`
-	InVs     []string `json:"inVs"`
-	Document string   `json:"document"`
+	OutV     uint64   `json:"outV"`
+	InVs     []uint64 `json:"inVs"`
+	Document uint64   `json:"document"`
 	Property string   `json:"property,omitempty"`
 }
 
-func NewItem(id, outV string, inVs []string, document string) *Item {
+func NewItem(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return &Item{
 		Edge: Edge{
 			Element: Element{
@@ -23,17 +23,17 @@ func NewItem(id, outV string, inVs []string, document string) *Item {
 	}
 }
 
-func NewItemWithProperty(id, outV string, inVs []string, document, property string) *Item {
+func NewItemWithProperty(id, outV uint64, inVs []uint64, document uint64, property string) *Item {
 	i := NewItem(id, outV, inVs, document)
 	i.Property = property
 	return i
 }
 
-func NewItemOfDefinitions(id, outV string, inVs []string, document string) *Item {
+func NewItemOfDefinitions(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return NewItemWithProperty(id, outV, inVs, document, "definitions")
 }
 
 // informationand in "references" relationship.
-func NewItemOfReferences(id, outV string, inVs []string, document string) *Item {
+func NewItemOfReferences(id, outV uint64, inVs []uint64, document uint64) *Item {
 	return NewItemWithProperty(id, outV, inVs, document, "references")
 }

--- a/protocol/metadata.go
+++ b/protocol/metadata.go
@@ -18,7 +18,7 @@ type ToolInfo struct {
 	Args    []string `json:"args,omitempty"`
 }
 
-func NewMetaData(id, root string, info ToolInfo) *MetaData {
+func NewMetaData(id uint64, root string, info ToolInfo) *MetaData {
 	return &MetaData{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/moniker.go
+++ b/protocol/moniker.go
@@ -7,7 +7,7 @@ type Moniker struct {
 	Identifier string `json:"identifier"`
 }
 
-func NewMoniker(id, kind, scheme, identifier string) *Moniker {
+func NewMoniker(id uint64, kind, scheme, identifier string) *Moniker {
 	return &Moniker{
 		Vertex: Vertex{
 			Element: Element{
@@ -24,11 +24,11 @@ func NewMoniker(id, kind, scheme, identifier string) *Moniker {
 
 type MonikerEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewMonikerEdge(id, outV, inV string) *MonikerEdge {
+func NewMonikerEdge(id, outV, inV uint64) *MonikerEdge {
 	return &MonikerEdge{
 		Edge: Edge{
 			Element: Element{
@@ -44,11 +44,11 @@ func NewMonikerEdge(id, outV, inV string) *MonikerEdge {
 
 type NextMonikerEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewNextMonikerEdge(id, outV, inV string) *NextMonikerEdge {
+func NewNextMonikerEdge(id, outV, inV uint64) *NextMonikerEdge {
 	return &NextMonikerEdge{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/next.go
+++ b/protocol/next.go
@@ -2,11 +2,11 @@ package protocol
 
 type Next struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewNext(id, outV, inV string) *Next {
+func NewNext(id, outV, inV uint64) *Next {
 	return &Next{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/package_information.go
+++ b/protocol/package_information.go
@@ -7,7 +7,7 @@ type PackageInformation struct {
 	Version string `json:"version"`
 }
 
-func NewPackageInformation(id, name, manager, version string) *PackageInformation {
+func NewPackageInformation(id uint64, name, manager, version string) *PackageInformation {
 	return &PackageInformation{
 		Vertex: Vertex{
 			Element: Element{
@@ -24,11 +24,11 @@ func NewPackageInformation(id, name, manager, version string) *PackageInformatio
 
 type PackageInformationEdge struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewPackageInformationEdge(id, outV, inV string) *PackageInformationEdge {
+func NewPackageInformationEdge(id, outV, inV uint64) *PackageInformationEdge {
 	return &PackageInformationEdge{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/project.go
+++ b/protocol/project.go
@@ -5,7 +5,7 @@ type Project struct {
 	Kind string `json:"kind"`
 }
 
-func NewProject(id string, languageID string) *Project {
+func NewProject(id uint64, languageID string) *Project {
 	return &Project{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/range.go
+++ b/protocol/range.go
@@ -11,7 +11,7 @@ type Pos struct {
 	Character int `json:"character"`
 }
 
-func NewRange(id string, start, end Pos) *Range {
+func NewRange(id uint64, start, end Pos) *Range {
 	return &Range{
 		Vertex: Vertex{
 			Element: Element{

--- a/protocol/reference.go
+++ b/protocol/reference.go
@@ -4,7 +4,7 @@ type ReferenceResult struct {
 	Vertex
 }
 
-func NewReferenceResult(id string) *ResultSet {
+func NewReferenceResult(id uint64) *ResultSet {
 	return &ResultSet{
 		Vertex: Vertex{
 			Element: Element{
@@ -18,11 +18,11 @@ func NewReferenceResult(id string) *ResultSet {
 
 type TextDocumentReferences struct {
 	Edge
-	OutV string `json:"outV"`
-	InV  string `json:"inV"`
+	OutV uint64 `json:"outV"`
+	InV  uint64 `json:"inV"`
 }
 
-func NewTextDocumentReferences(id, outV, inV string) *TextDocumentReferences {
+func NewTextDocumentReferences(id, outV, inV uint64) *TextDocumentReferences {
 	return &TextDocumentReferences{
 		Edge: Edge{
 			Element: Element{

--- a/protocol/resultset.go
+++ b/protocol/resultset.go
@@ -4,7 +4,7 @@ type ResultSet struct {
 	Vertex
 }
 
-func NewResultSet(id string) *ResultSet {
+func NewResultSet(id uint64) *ResultSet {
 	return &ResultSet{
 		Vertex: Vertex{
 			Element: Element{


### PR DESCRIPTION
The majority of time was spent on syscalls for small writes to files. Buffering this speeds up indexing **significantly**. Indexing aws-sdk-go took 8 minutes in version 0.9.0. Before this change it takes
 about 90 seconds. After this change about 32 seconds.