### PR TITLE
Remove error result from runParallel functions.

### DIFF
--- a/internal/indexer/parallel_test.go
+++ b/internal/indexer/parallel_test.go
@@ -1,42 +1,23 @@
 package indexer
 
 import (
-	"fmt"
-	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 )
 
 func TestRunParallel(t *testing.T) {
-	ch := make(chan func() error, 3)
-	ch <- func() error { return nil }
-	ch <- func() error { return nil }
-	ch <- func() error { return nil }
+	ch := make(chan func(), 3)
+	ch <- func() {}
+	ch <- func() {}
+	ch <- func() {}
 	close(ch)
 
-	wg, errs, n := runParallel(ch)
-
+	wg, n := runParallel(ch)
 	wg.Wait()
-	if err := <-errs; err != nil {
-		t.Fatalf("unexpected error: %s", err)
-	}
+
 	if *n != 3 {
 		t.Errorf("unexpected count. want=%d want=%d", 3, *n)
-	}
-}
-
-func TestRunParallelFailure(t *testing.T) {
-	ch := make(chan func() error, 3)
-	ch <- func() error { return nil }
-	ch <- func() error { return fmt.Errorf("oops") }
-	ch <- func() error { return nil }
-	close(ch)
-
-	wg, errs, _ := runParallel(ch)
-	wg.Wait()
-	if err := <-errs; err == nil || !strings.Contains(err.Error(), "oops") {
-		t.Fatalf("unexpected error. want=%s have=%v", "oops", err)
 	}
 }
 
@@ -45,13 +26,13 @@ func TestRunParallelProgress(t *testing.T) {
 	sync2 := make(chan struct{})
 	sync3 := make(chan struct{})
 
-	ch := make(chan func() error, 3)
-	ch <- func() error { <-sync1; return nil }
-	ch <- func() error { <-sync2; return nil }
-	ch <- func() error { <-sync3; return nil }
+	ch := make(chan func(), 3)
+	ch <- func() { <-sync1 }
+	ch <- func() { <-sync2 }
+	ch <- func() { <-sync3 }
 	close(ch)
 
-	wg, _, n := runParallel(ch)
+	wg, n := runParallel(ch)
 
 	checkValue := func(expected uint64) {
 		var v uint64

--- a/internal/indexer/visit.go
+++ b/internal/indexer/visit.go
@@ -31,77 +31,62 @@ func (i *Indexer) visitEachRawFile(name string, animate, silent bool, fn func(fi
 		}
 	}()
 
-	withProgress(&wg, name, animate, silent, &count, &n)
+	withProgress(&wg, name, animate, silent, &count, n)
 }
 
 // visitEachPackage invokes the given visitor function on each indexed package. This method prints the
 // progress of the traversal to stdout asynchronously.
 func (i *Indexer) visitEachPackage(name string, animate, silent bool, fn func(p *packages.Package)) {
-	ch := make(chan func() error)
+	ch := make(chan func())
 
 	go func() {
 		defer close(ch)
 
 		for _, p := range i.packages {
-			ch <- func(p *packages.Package) func() error {
-				return func() error {
-					fn(p)
-					return nil
-				}
-			}(p)
+			t := p
+			ch <- func() { fn(t) }
 		}
 	}()
 
 	n := uint64(len(i.packages))
-	wg, errs, count := runParallel(ch)
-	withProgress(wg, name, i.animate, i.silent, count, &n)
-	<-errs
+	wg, count := runParallel(ch)
+	withProgress(wg, name, i.animate, i.silent, count, n)
 }
 
 // visitEachReferenceResult invokes the given visitor function on each reference result. This method
 // prints the progress of the traversal to stdout asynchronously.
 func (i *Indexer) visitEachReferenceResult(name string, animate, silent bool, fn func(referenceResult *ReferenceResultInfo)) {
-	ch := make(chan func() error)
+	ch := make(chan func())
 
 	go func() {
 		defer close(ch)
 
 		for _, r := range i.referenceResults {
-			ch <- func(r *ReferenceResultInfo) func() error {
-				return func() error {
-					fn(r)
-					return nil
-				}
-			}(r)
+			t := r
+			ch <- func() { fn(t) }
 		}
 	}()
 
 	n := uint64(len(i.referenceResults))
-	wg, errs, count := runParallel(ch)
-	withProgress(wg, name, i.animate, i.silent, count, &n)
-	<-errs
+	wg, count := runParallel(ch)
+	withProgress(wg, name, i.animate, i.silent, count, n)
 }
 
 // visitEachDocument invokes the given visitor function on each document. This method prints the
 // progress of the traversal to stdout asynchronously.
 func (i *Indexer) visitEachDocument(name string, animate, silent bool, fn func(d *DocumentInfo)) {
-	ch := make(chan func() error)
+	ch := make(chan func())
 
 	go func() {
 		defer close(ch)
 
 		for _, d := range i.documents {
-			ch <- func(d *DocumentInfo) func() error {
-				return func() error {
-					fn(d)
-					return nil
-				}
-			}(d)
+			t := d
+			ch <- func() { fn(t) }
 		}
 	}()
 
 	n := uint64(len(i.documents))
-	wg, errs, count := runParallel(ch)
-	withProgress(wg, name, i.animate, i.silent, count, &n)
-	<-errs
+	wg, count := runParallel(ch)
+	withProgress(wg, name, i.animate, i.silent, count, n)
 }


### PR DESCRIPTION
This also allows us to shed a layer of closures in most of our visitor functions.