### PR TITLE
Fix slice index out of bounds error

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -311,7 +311,7 @@ func (i *Indexer) positionAndDocument(p *packages.Package, ident *ast.Ident, obj
 
 	pos := p.Fset.Position(ident.Pos())
 
-	if i.packagesByFile[pos.Filename][0] != p {
+	if packages := i.packagesByFile[pos.Filename]; len(packages) == 0 || packages[0] != p {
 		return token.Position{}, nil, false
 	}
 


### PR DESCRIPTION
Reported as part of https://sourcegraph.atlassian.net/jira/servicedesk/projects/SG/queues/custom/1/SG-327.

This is a bit of a strange issue - it appears as though one of the uses within a package belongs to a file that isn't actually in any of the indexed packages. Will try to follow up to see root cause.