### PR TITLE
Preload on demand

### DIFF
--- a/cmd/lsif-go/index.go
+++ b/cmd/lsif-go/index.go
@@ -25,6 +25,8 @@ func writeIndex(repositoryRoot, projectRoot, moduleName, moduleVersion string, d
 		Args:    os.Args[1:],
 	}
 
+	preloader := indexer.NewPreloader()
+
 	// TODO(efritz) - With cgo enabled, the indexer cannot handle packages
 	// that include assembly (.s) files. To index such a package you need to
 	// set CGO_ENABLED=0. Consider maybe doing this explicitly, always.
@@ -36,6 +38,7 @@ func writeIndex(repositoryRoot, projectRoot, moduleName, moduleVersion string, d
 		moduleVersion,
 		dependencies,
 		writer.NewJSONWriter(out),
+		preloader,
 		!noProgress,
 		noOutput,
 		verboseOutput,
@@ -46,7 +49,7 @@ func writeIndex(repositoryRoot, projectRoot, moduleName, moduleVersion string, d
 	}
 
 	if !noOutput && verboseOutput {
-		displayStats(indexer.Stats(), start)
+		displayStats(indexer.Stats(), preloader.Stats(), start)
 	}
 
 	return nil

--- a/cmd/lsif-go/stats.go
+++ b/cmd/lsif-go/stats.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sourcegraph/lsif-go/internal/util"
 )
 
-func displayStats(indexerStats *indexer.IndexerStats, start time.Time) {
+func displayStats(indexerStats indexer.IndexerStats, preloaderStats indexer.PreloaderStats, start time.Time) {
 	stats := []struct {
 		name  string
 		value string
@@ -19,6 +19,7 @@ func displayStats(indexerStats *indexer.IndexerStats, start time.Time) {
 		{"Files indexed", fmt.Sprintf("%d", indexerStats.NumFiles)},
 		{"Definitions indexed", fmt.Sprintf("%d", indexerStats.NumDefs)},
 		{"Elements emitted", fmt.Sprintf("%d", indexerStats.NumElements)},
+		{"Unique packages traversed", fmt.Sprintf("%d", preloaderStats.NumPks)},
 	}
 
 	n := 0

--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -70,17 +70,6 @@ func findUseByName(t *testing.T, packages []*packages.Package, name string) (*pa
 	return nil, nil
 }
 
-// preload populates and returns a Preloader instance with the hover text and moniker
-// paths for all definitions in in the given packages.
-func preload(packages []*packages.Package) *Preloader {
-	preloader := newPreloader()
-	for _, p := range getAllReferencedPackages(packages) {
-		preloader.Load(p)
-	}
-
-	return preloader
-}
-
 // normalizeDocstring removes leading indentation from each line, removes empty lines,
 // trims trailing whitespace, and returns the remaining lines joined by a single space.
 func normalizeDocstring(s string) string {

--- a/internal/indexer/hover_test.go
+++ b/internal/indexer/hover_test.go
@@ -7,12 +7,13 @@ import (
 func TestFindDocstringFunc(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "ParallelizableFunc")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`
 		ParallelizableFunc is a function that can be called concurrently with other instances
 		of this function type.
 	`)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -20,9 +21,10 @@ func TestFindDocstringFunc(t *testing.T) {
 func TestFindDocstringInterface(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "TestInterface")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`TestInterface is an interface used for testing.`)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -30,9 +32,10 @@ func TestFindDocstringInterface(t *testing.T) {
 func TestFindDocstringStruct(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "TestStruct")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`TestStruct is a struct used for testing.`)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -40,9 +43,10 @@ func TestFindDocstringStruct(t *testing.T) {
 func TestFindDocstringField(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "NestedC")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`NestedC docs`)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -50,9 +54,10 @@ func TestFindDocstringField(t *testing.T) {
 func TestFindDocstringConst(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "Score")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`Score is just a hardcoded number.`)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -64,9 +69,10 @@ func TestFindDocstringConst(t *testing.T) {
 func TestFindDocstringLocalVariable(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "errs")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(``)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -74,9 +80,10 @@ func TestFindDocstringLocalVariable(t *testing.T) {
 func TestFindDocstringInternalPackageName(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findUseByName(t, packages, "secret")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`secret is a package that holds secrets.`)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -84,6 +91,7 @@ func TestFindDocstringInternalPackageName(t *testing.T) {
 func TestFindDocstringExternalPackageName(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findUseByName(t, packages, "sync")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`
 		Package sync provides basic synchronization primitives such as mutual exclusion locks.
@@ -91,7 +99,7 @@ func TestFindDocstringExternalPackageName(t *testing.T) {
 		Higher-level synchronization is better done via channels and communication.
 		Values containing the types defined in this package should not be copied.
 	`)
-	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }
@@ -99,6 +107,7 @@ func TestFindDocstringExternalPackageName(t *testing.T) {
 func TestFindExternalDocstring(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findUseByName(t, packages, "WaitGroup")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`
 		A WaitGroup waits for a collection of goroutines to finish.
@@ -107,7 +116,7 @@ func TestFindExternalDocstring(t *testing.T) {
 		At the same time, Wait can be used to block until all goroutines have finished.
 		A WaitGroup must not be copied after first use.
 	`)
-	if text := normalizeDocstring(findExternalDocstring(preload(packages), packages, p, obj)); text != expectedText {
+	if text := normalizeDocstring(findExternalDocstring(preloader, packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}
 }

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -11,6 +11,7 @@ import (
 func TestIndexer(t *testing.T) {
 	w := &capturingWriter{}
 	projectRoot := getRepositoryRoot(t)
+	preloader := NewPreloader()
 	indexer := New(
 		"/dev/github.com/sourcegraph/lsif-go/internal/testdata",
 		projectRoot,
@@ -19,6 +20,7 @@ func TestIndexer(t *testing.T) {
 		"0.0.1",
 		nil,
 		w,
+		preloader,
 		false,
 		true,
 		false,

--- a/internal/indexer/info.go
+++ b/internal/indexer/info.go
@@ -10,6 +10,11 @@ type IndexerStats struct {
 	NumElements uint64
 }
 
+// PreloaderStats summarizes the amount of work done by the preloader.
+type PreloaderStats struct {
+	NumPks uint
+}
+
 // DocumentInfo provides context for constructing the contains relationship between
 // a document and the ranges that it contains.
 type DocumentInfo struct {

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -126,8 +126,9 @@ func TestMonikerIdentifierBasic(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findUseByName(t, packages, "Score")
 	ident := &ast.Ident{Name: "Score", NamePos: obj.Pos()}
+	preloader := NewPreloader()
 
-	if identifier := monikerIdentifier(preload(packages), p, ident, obj); identifier != "Score" {
+	if identifier := monikerIdentifier(preloader, p, ident, obj); identifier != "Score" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "Score", identifier)
 	}
 }
@@ -136,8 +137,9 @@ func TestMonikerIdentifierPackageName(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findUseByName(t, packages, "sync")
 	ident := &ast.Ident{Name: "sync", NamePos: obj.Pos()}
+	preloader := NewPreloader()
 
-	if identifier := monikerIdentifier(preload(packages), p, ident, obj); identifier != "" {
+	if identifier := monikerIdentifier(preloader, p, ident, obj); identifier != "" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "", identifier)
 	}
 }
@@ -146,8 +148,9 @@ func TestMonikerIdentifierSignature(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "Doer")
 	ident := &ast.Ident{Name: "Doer", NamePos: obj.Pos()}
+	preloader := NewPreloader()
 
-	if identifier := monikerIdentifier(preload(packages), p, ident, obj); identifier != "TestStruct.Doer" {
+	if identifier := monikerIdentifier(preloader, p, ident, obj); identifier != "TestStruct.Doer" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "TestStruct.Doer", identifier)
 	}
 }
@@ -156,8 +159,9 @@ func TestMonikerIdentifierField(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "NestedB")
 	ident := &ast.Ident{Name: "NestedB", NamePos: obj.Pos()}
+	preloader := NewPreloader()
 
-	if identifier := monikerIdentifier(preload(packages), p, ident, obj); identifier != "TestStruct.FieldWithAnonymousType.NestedB" {
+	if identifier := monikerIdentifier(preloader, p, ident, obj); identifier != "TestStruct.FieldWithAnonymousType.NestedB" {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "TestStruct.FieldWithAnonymousType.NestedB", identifier)
 	}
 }

--- a/internal/indexer/preloader_test.go
+++ b/internal/indexer/preloader_test.go
@@ -4,8 +4,8 @@ import "testing"
 
 func TestPreloader(t *testing.T) {
 	packages := getTestPackages(t)
-	preloader := preload(packages)
 	p, obj := findDefinitionByName(t, packages, "ParallelizableFunc")
+	preloader := NewPreloader()
 
 	expectedText := normalizeDocstring(`
 		ParallelizableFunc is a function that can be called concurrently with other instances


### PR DESCRIPTION
This updates the preloader to only load data for packages on their first use. This has the effect of only loading packages just-in-time, which saves us the pre-step of parsing all packages at once. This may also save some memory if packages are imported but no identifier is referenced in a way in which we need to extract hover text or get a moniker path.