### PR TITLE
Move Emitter and JSONWriter to protocol package

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -9,8 +9,6 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
-	"github.com/sourcegraph/lsif-go/internal/writer"
-	protocolwriter "github.com/sourcegraph/lsif-go/internal/writer"
 	"github.com/sourcegraph/lsif-go/protocol"
 	"golang.org/x/tools/go/packages"
 )
@@ -22,7 +20,7 @@ type Indexer struct {
 	moduleName     string            // name of this module
 	moduleVersion  string            // version of this module
 	dependencies   map[string]string // parsed module data
-	emitter        *writer.Emitter   // LSIF data emitter
+	emitter        *protocol.Emitter // LSIF data emitter
 	animate        bool              // Whether to animate output
 	silent         bool              // Whether to suppress all output
 	verbose        bool              // Whether to display elapsed time
@@ -63,7 +61,7 @@ func New(
 	moduleName string,
 	moduleVersion string,
 	dependencies map[string]string,
-	writer protocolwriter.JSONWriter,
+	writer protocol.JSONWriter,
 	animate bool,
 	silent bool,
 	verbose bool,
@@ -75,7 +73,7 @@ func New(
 		moduleName:            moduleName,
 		moduleVersion:         moduleVersion,
 		dependencies:          dependencies,
-		emitter:               protocolwriter.NewEmitter(writer),
+		emitter:               protocol.NewEmitter(writer),
 		animate:               animate,
 		silent:                silent,
 		verbose:               verbose,

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/sourcegraph/lsif-go/internal/writer"
+	"github.com/sourcegraph/lsif-go/protocol"
 )
 
 func TestEmitExportMoniker(t *testing.T) {
@@ -17,7 +17,7 @@ func TestEmitExportMoniker(t *testing.T) {
 	indexer := &Indexer{
 		moduleName:            "github.com/sourcegraph/lsif-go",
 		moduleVersion:         "3.14.159",
-		emitter:               writer.NewEmitter(w),
+		emitter:               protocol.NewEmitter(w),
 		packageInformationIDs: map[string]uint64{},
 		stripedMutex:          newStripedMutex(),
 	}
@@ -65,7 +65,7 @@ func TestEmitImportMoniker(t *testing.T) {
 		dependencies: map[string]string{
 			"github.com/test/pkg/sub1": "1.2.3-deadbeef",
 		},
-		emitter:               writer.NewEmitter(w),
+		emitter:               protocol.NewEmitter(w),
 		packageInformationIDs: map[string]uint64{},
 		stripedMutex:          newStripedMutex(),
 	}

--- a/internal/writer/writer.go
+++ b/internal/writer/writer.go
@@ -6,19 +6,10 @@ import (
 	"sync"
 
 	jsoniter "github.com/json-iterator/go"
+	"github.com/sourcegraph/lsif-go/protocol"
 )
 
 var marshaller = jsoniter.ConfigFastest
-
-// JSONWriter serializes vertexes and edges into JSON and writes them to an
-// underlying writer as newline-delimited JSON.
-type JSONWriter interface {
-	// Write emits a single vertex or edge value.
-	Write(v interface{})
-
-	// Flush ensures that all elements have been written to the underlying writer.
-	Flush() error
-}
 
 type jsonWriter struct {
 	wg             sync.WaitGroup
@@ -27,6 +18,8 @@ type jsonWriter struct {
 	err            error
 }
 
+var _ protocol.JSONWriter = &jsonWriter{}
+
 // channelBufferSize is the number of elements that can be queued to be written.
 const channelBufferSize = 512
 
@@ -34,7 +27,7 @@ const channelBufferSize = 512
 const writerBufferSize = 4096
 
 // NewJSONWriter creates a new JSONWriter wrapping the given writer.
-func NewJSONWriter(w io.Writer) JSONWriter {
+func NewJSONWriter(w io.Writer) protocol.JSONWriter {
 	ch := make(chan interface{}, channelBufferSize)
 	bufferedWriter := bufio.NewWriterSize(w, writerBufferSize)
 	jw := &jsonWriter{ch: ch, bufferedWriter: bufferedWriter}

--- a/protocol/emitter.go
+++ b/protocol/emitter.go
@@ -1,10 +1,6 @@
-package writer
+package protocol
 
-import (
-	"sync/atomic"
-
-	"github.com/sourcegraph/lsif-go/protocol"
-)
+import "sync/atomic"
 
 // Emitter creates vertex and edge values and passes them to the underlying
 // JSONWriter instance. Use of this struct guarantees that unique identifiers
@@ -14,129 +10,139 @@ type Emitter struct {
 	id     uint64
 }
 
+// JSONWriter serializes vertexes and edges into JSON and writes them to an
+// underlying writer as newline-delimited JSON.
+type JSONWriter interface {
+	// Write emits a single vertex or edge value.
+	Write(v interface{})
+
+	// Flush ensures that all elements have been written to the underlying writer.
+	Flush() error
+}
+
 func NewEmitter(writer JSONWriter) *Emitter {
 	return &Emitter{
 		writer: writer,
 	}
 }
 
-func (e *Emitter) EmitMetaData(root string, info protocol.ToolInfo) uint64 {
+func (e *Emitter) EmitMetaData(root string, info ToolInfo) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewMetaData(id, root, info))
+	e.writer.Write(NewMetaData(id, root, info))
 	return id
 }
 
 func (e *Emitter) EmitProject(languageID string) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewProject(id, languageID))
+	e.writer.Write(NewProject(id, languageID))
 	return id
 }
 
 func (e *Emitter) EmitDocument(languageID, path string) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewDocument(id, languageID, "file://"+path))
+	e.writer.Write(NewDocument(id, languageID, "file://"+path))
 	return id
 }
 
-func (e *Emitter) EmitRange(start, end protocol.Pos) uint64 {
+func (e *Emitter) EmitRange(start, end Pos) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewRange(id, start, end))
+	e.writer.Write(NewRange(id, start, end))
 	return id
 }
 
 func (e *Emitter) EmitResultSet() uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewResultSet(id))
+	e.writer.Write(NewResultSet(id))
 	return id
 }
 
-func (e *Emitter) EmitHoverResult(contents []protocol.MarkedString) uint64 {
+func (e *Emitter) EmitHoverResult(contents []MarkedString) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewHoverResult(id, contents))
+	e.writer.Write(NewHoverResult(id, contents))
 	return id
 }
 
 func (e *Emitter) EmitTextDocumentHover(outV, inV uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewTextDocumentHover(id, outV, inV))
+	e.writer.Write(NewTextDocumentHover(id, outV, inV))
 	return id
 }
 
 func (e *Emitter) EmitDefinitionResult() uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewDefinitionResult(id))
+	e.writer.Write(NewDefinitionResult(id))
 	return id
 }
 
 func (e *Emitter) EmitTextDocumentDefinition(outV, inV uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewTextDocumentDefinition(id, outV, inV))
+	e.writer.Write(NewTextDocumentDefinition(id, outV, inV))
 	return id
 }
 
 func (e *Emitter) EmitReferenceResult() uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewReferenceResult(id))
+	e.writer.Write(NewReferenceResult(id))
 	return id
 }
 
 func (e *Emitter) EmitTextDocumentReferences(outV, inV uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewTextDocumentReferences(id, outV, inV))
+	e.writer.Write(NewTextDocumentReferences(id, outV, inV))
 	return id
 }
 
 func (e *Emitter) EmitItem(outV uint64, inVs []uint64, docID uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewItem(id, outV, inVs, docID))
+	e.writer.Write(NewItem(id, outV, inVs, docID))
 	return id
 }
 
 func (e *Emitter) EmitItemOfDefinitions(outV uint64, inVs []uint64, docID uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewItemOfDefinitions(id, outV, inVs, docID))
+	e.writer.Write(NewItemOfDefinitions(id, outV, inVs, docID))
 	return id
 }
 
 func (e *Emitter) EmitItemOfReferences(outV uint64, inVs []uint64, docID uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewItemOfReferences(id, outV, inVs, docID))
+	e.writer.Write(NewItemOfReferences(id, outV, inVs, docID))
 	return id
 }
 
 func (e *Emitter) EmitMoniker(kind, scheme, identifier string) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewMoniker(id, kind, scheme, identifier))
+	e.writer.Write(NewMoniker(id, kind, scheme, identifier))
 	return id
 }
 
 func (e *Emitter) EmitMonikerEdge(outV, inV uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewMonikerEdge(id, outV, inV))
+	e.writer.Write(NewMonikerEdge(id, outV, inV))
 	return id
 }
 
 func (e *Emitter) EmitPackageInformation(packageName, scheme, version string) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewPackageInformation(id, packageName, scheme, version))
+	e.writer.Write(NewPackageInformation(id, packageName, scheme, version))
 	return id
 }
 
 func (e *Emitter) EmitPackageInformationEdge(outV, inV uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewPackageInformationEdge(id, outV, inV))
+	e.writer.Write(NewPackageInformationEdge(id, outV, inV))
 	return id
 }
 
 func (e *Emitter) EmitContains(outV uint64, inVs []uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewContains(id, outV, inVs))
+	e.writer.Write(NewContains(id, outV, inVs))
 	return id
 }
 
 func (e *Emitter) EmitNext(outV, inV uint64) uint64 {
 	id := e.nextID()
-	e.writer.Write(protocol.NewNext(id, outV, inV))
+	e.writer.Write(NewNext(id, outV, inV))
 	return id
 }
 


### PR DESCRIPTION
This functionality is used by lsif-semanticdb and some other utilities. We should move this to a new library in the longer term.