### PR TITLE
Simplify preloader map data

### DIFF
--- a/internal/indexer/helpers_test.go
+++ b/internal/indexer/helpers_test.go
@@ -75,7 +75,7 @@ func findUseByName(t *testing.T, packages []*packages.Package, name string) (*pa
 func preload(packages []*packages.Package) *Preloader {
 	preloader := newPreloader()
 	for _, p := range getAllReferencedPackages(packages) {
-		preloader.Load(p, getDefinitionPositions(p))
+		preloader.Load(p)
 	}
 
 	return preloader

--- a/internal/indexer/hover.go
+++ b/internal/indexer/hover.go
@@ -73,15 +73,14 @@ func makeCacheKey(pkg *types.Package, obj types.Object) string {
 	return ""
 }
 
-// findDocstring extracts the comments form the given object. It is assumed that this object is
+// findDocstring extracts the comments from the given object. It is assumed that this object is
 // declared in an index target (otherwise, findExternalDocstring should be called).
 func findDocstring(preloader *Preloader, pkgs []*packages.Package, p *packages.Package, obj types.Object) string {
 	if obj == nil {
 		return ""
 	}
 
-	switch v := obj.(type) {
-	case *types.PkgName:
+	if v, ok := obj.(*types.PkgName); ok {
 		return findPackageDocstring(pkgs, p, v)
 	}
 
@@ -89,15 +88,14 @@ func findDocstring(preloader *Preloader, pkgs []*packages.Package, p *packages.P
 	return preloader.Text(p, obj.Pos())
 }
 
-// findExternalDocstring extracts the comments form the given object. It is assumed that this object is
+// findExternalDocstring extracts the comments from the given object. It is assumed that this object is
 // declared in a dependency.
 func findExternalDocstring(preloader *Preloader, pkgs []*packages.Package, p *packages.Package, obj types.Object) string {
 	if obj == nil {
 		return ""
 	}
 
-	switch v := obj.(type) {
-	case *types.PkgName:
+	if v, ok := obj.(*types.PkgName); ok {
 		return findPackageDocstring(pkgs, p, v)
 	}
 
@@ -132,8 +130,8 @@ func findPackageDocstring(pkgs []*packages.Package, p *packages.Package, target 
 // extractPackagedocstring returns the first doc text attached to a file in the given package.
 func extractPackageDocstring(p *packages.Package) string {
 	for _, f := range p.Syntax {
-		if f.Doc.Text() != "" {
-			return f.Doc.Text()
+		if text := f.Doc.Text(); text != "" {
+			return text
 		}
 	}
 

--- a/internal/indexer/hover_test.go
+++ b/internal/indexer/hover_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 )
 
-func TestFindDocstring(t *testing.T) {
+func TestFindDocstringFunc(t *testing.T) {
 	packages := getTestPackages(t)
 	p, obj := findDefinitionByName(t, packages, "ParallelizableFunc")
 
@@ -12,6 +12,60 @@ func TestFindDocstring(t *testing.T) {
 		ParallelizableFunc is a function that can be called concurrently with other instances
 		of this function type.
 	`)
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
+	}
+}
+
+func TestFindDocstringInterface(t *testing.T) {
+	packages := getTestPackages(t)
+	p, obj := findDefinitionByName(t, packages, "TestInterface")
+
+	expectedText := normalizeDocstring(`TestInterface is an interface used for testing.`)
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
+	}
+}
+
+func TestFindDocstringStruct(t *testing.T) {
+	packages := getTestPackages(t)
+	p, obj := findDefinitionByName(t, packages, "TestStruct")
+
+	expectedText := normalizeDocstring(`TestStruct is a struct used for testing.`)
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
+	}
+}
+
+func TestFindDocstringField(t *testing.T) {
+	packages := getTestPackages(t)
+	p, obj := findDefinitionByName(t, packages, "NestedC")
+
+	expectedText := normalizeDocstring(`NestedC docs`)
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
+	}
+}
+
+func TestFindDocstringConst(t *testing.T) {
+	packages := getTestPackages(t)
+	p, obj := findDefinitionByName(t, packages, "Score")
+
+	expectedText := normalizeDocstring(`Score is just a hardcoded number.`)
+	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
+		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
+	}
+}
+
+// TestFindDocstringLocalVariable ensures that local definitions within a function with a
+// docstring do not take their parent's docstring as their own. This was a brief (unpublished)
+// regression made when switching from storing node paths for hover text extraction to only
+// storing a single ancestor node from which hover text is extracted.
+func TestFindDocstringLocalVariable(t *testing.T) {
+	packages := getTestPackages(t)
+	p, obj := findDefinitionByName(t, packages, "errs")
+
+	expectedText := normalizeDocstring(``)
 	if text := normalizeDocstring(findDocstring(preload(packages), packages, p, obj)); text != expectedText {
 		t.Errorf("unexpected hover text. want=%q have=%q", expectedText, text)
 	}

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -4,7 +4,6 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"sort"
 	"strings"
 	"sync"
 
@@ -232,27 +231,13 @@ func (i *Indexer) preload() {
 
 		for _, p := range pkgs {
 			t := p
-			ch <- func() { i.preloader.Load(t, getDefinitionPositions(t)) }
+			ch <- func() { i.preloader.Load(t) }
 		}
 	}()
 
 	// Load hovers for each package concurrently
 	wg, count := runParallel(ch)
 	withProgress(wg, "Preloading hover text and moniker paths", i.animate, i.silent, i.verbose, count, uint64(len(pkgs)))
-}
-
-// getDefinitionPositions extracts the positions of all definitions from the given package. This
-// returns a sorted slice.
-func getDefinitionPositions(p *packages.Package) []token.Pos {
-	positions := make([]token.Pos, 0, len(p.TypesInfo.Defs))
-	for _, obj := range p.TypesInfo.Defs {
-		if obj != nil {
-			positions = append(positions, obj.Pos())
-		}
-	}
-
-	sort.Slice(positions, func(i, j int) bool { return positions[i] < positions[j] })
-	return positions
 }
 
 // getAllReferencedPackages returns a slice of packages containing the index target packages

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -83,7 +83,7 @@ func TestIndexer(t *testing.T) {
 	})
 
 	t.Run("check errs definition", func(t *testing.T) {
-		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 23, 3)
+		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 21, 3)
 		if !ok {
 			t.Fatalf("could not find target range")
 		}
@@ -97,7 +97,7 @@ func TestIndexer(t *testing.T) {
 	})
 
 	t.Run("check wg references", func(t *testing.T) {
-		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 27, 1)
+		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 26, 1)
 		if !ok {
 			t.Fatalf("could not find target range")
 		}
@@ -109,14 +109,14 @@ func TestIndexer(t *testing.T) {
 
 		sort.Slice(references, func(i, j int) bool { return references[i].Start.Line < references[j].Start.Line })
 
-		compareRange(t, references[0], 14, 5, 14, 7)  // var wg sync.WaitGroup
-		compareRange(t, references[1], 18, 2, 18, 4)  // wg.Add(1)
-		compareRange(t, references[2], 21, 9, 21, 11) // defer wg.Done()
-		compareRange(t, references[3], 27, 1, 27, 3)  // wg.Wait()
+		compareRange(t, references[0], 14, 5, 14, 7) // var wg sync.WaitGroup
+		compareRange(t, references[1], 18, 2, 18, 4) // wg.Add(1)
+		compareRange(t, references[2], 22, 3, 22, 5) // wg.Done()
+		compareRange(t, references[3], 26, 1, 26, 3) // wg.Wait()
 	})
 
 	t.Run("check NestedB monikers", func(t *testing.T) {
-		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "data.go"), 26, 2)
+		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "data.go"), 27, 3)
 		if !ok {
 			t.Fatalf("could not find target range")
 		}

--- a/internal/indexer/preloader.go
+++ b/internal/indexer/preloader.go
@@ -4,45 +4,36 @@ import (
 	"go/ast"
 	"go/token"
 	"go/types"
-	"sort"
 	"strings"
 	"sync"
 
 	"golang.org/x/tools/go/packages"
 )
 
-// nodePathLength is the number of ancestor nodes that will be searched when trying to extract a
-// comment from a particular AST node.
-const nodePathLength = 3
-
-// nodePath is a fixed-size array of AST nodes.
-type nodePath = [nodePathLength]ast.Node
-
 // Preloader is a cache of hover text and enclosing type identifiers by file and token position.
 type Preloader struct {
 	m            sync.RWMutex
-	hoverText    map[*packages.Package]map[token.Pos]nodePath
+	hoverText    map[*packages.Package]map[token.Pos]ast.Node
 	monikerPaths map[*packages.Package]map[token.Pos][]string
 }
 
 // newPreloader creates a new empty Preloader.
 func newPreloader() *Preloader {
 	return &Preloader{
-		hoverText:    map[*packages.Package]map[token.Pos]nodePath{},
+		hoverText:    map[*packages.Package]map[token.Pos]ast.Node{},
 		monikerPaths: map[*packages.Package]map[token.Pos][]string{},
 	}
 }
 
 // Load will walk the AST of each file in the given package and cache the hover text and moniker
-// paths for each of the given positions. This function assumes that the given positions are already
-// ordered so that a binary-search can be used to efficiently bound lookups.
-func (l *Preloader) Load(p *packages.Package, positions []token.Pos) {
-	definitionPositions, fieldPositions := interestingPositions(p)
-	hoverTextMap := map[token.Pos]nodePath{}
+// paths for each interesting position in the
+func (l *Preloader) Load(p *packages.Package) {
+	hoverTextPositions, monikerPathPositions := interestingPositions(p)
+	hoverTextMap := map[token.Pos]ast.Node{}
 	monikerPathMap := map[token.Pos][]string{}
 
 	for _, root := range p.Syntax {
-		visit(root, definitionPositions, fieldPositions, hoverTextMap, monikerPathMap, nodePath{}, nil)
+		visit(root, hoverTextPositions, monikerPathPositions, hoverTextMap, monikerPathMap, nil, nil)
 	}
 
 	l.m.Lock()
@@ -51,49 +42,47 @@ func (l *Preloader) Load(p *packages.Package, positions []token.Pos) {
 	l.m.Unlock()
 }
 
-// interestingPositions returns a sorted slice of token positions represeting the location of all definitions
-// of the given package, and a map of all unique token positions representing the location of fields. This is
-// used to determine which positions should have preloaded data held in memory (as doing it for every node in
-// the package's AST will occupy too much memory needlessly).
-func interestingPositions(p *packages.Package) ([]token.Pos, map[token.Pos]struct{}) {
-	definitionPositions := make([]token.Pos, 0, len(p.TypesInfo.Defs))
-	fieldPositions := make(map[token.Pos]struct{}, len(p.TypesInfo.Defs)+len(p.TypesInfo.Uses))
-
-	for _, obj := range p.TypesInfo.Defs {
-		if obj != nil {
-			definitionPositions = append(definitionPositions, obj.Pos())
-		}
-
-		if v, ok := obj.(*types.Var); ok && v.IsField() {
-			fieldPositions[obj.Pos()] = struct{}{}
-		}
-	}
-
-	for _, obj := range p.TypesInfo.Uses {
-		if v, ok := obj.(*types.Var); ok && v.IsField() {
-			fieldPositions[obj.Pos()] = struct{}{}
-		}
-	}
-
-	// We run binary search over this so we need to ensure that it's ordered
-	sort.Slice(definitionPositions, func(i, j int) bool { return definitionPositions[i] < definitionPositions[j] })
-
-	return definitionPositions, fieldPositions
-}
-
-// Text will return the hover text extracted from the given package. For non-empty hover text to
-// be returned from this method, Load must have been previously called with this package and position
-// as arguments.
+// Text will return the hover text for the given token position extracted from the given package. For a
+// non-empty hover text to be returned from this method, Load must have been previously called with this
+// package as an argument.
 func (l *Preloader) Text(p *packages.Package, position token.Pos) string {
 	l.m.RLock()
 	defer l.m.RUnlock()
-	return commentsFromPath(l.hoverText[p][position])
+	return extractHoverText(l.hoverText[p][position])
 }
 
+// MonikerPath returns the names of types enclosing the given position extracted from the given package.
+// For a non-empty path to be returned from this method, Load must have been previously called with this
+// package as an argument.
 func (l *Preloader) MonikerPath(p *packages.Package, position token.Pos) []string {
 	l.m.RLock()
 	defer l.m.RUnlock()
 	return l.monikerPaths[p][position]
+}
+
+// interestingPositions returns a pair of maps whose keys are token positions for which we want values
+// in the preloader's hoverText and monikerPaths maps. Determining which types of types we will query
+// for this data and populating values only for those nodes saves a lot of resident memory.
+func interestingPositions(p *packages.Package) (map[token.Pos]struct{}, map[token.Pos]struct{}) {
+	hoverTextPositions := map[token.Pos]struct{}{}
+	monikerPathPositions := map[token.Pos]struct{}{}
+
+	for _, obj := range p.TypesInfo.Defs {
+		if shouldHaveHoverText(obj) {
+			hoverTextPositions[obj.Pos()] = struct{}{}
+		}
+		if isField(obj) {
+			monikerPathPositions[obj.Pos()] = struct{}{}
+		}
+	}
+
+	for _, obj := range p.TypesInfo.Uses {
+		if isField(obj) {
+			monikerPathPositions[obj.Pos()] = struct{}{}
+		}
+	}
+
+	return hoverTextPositions, monikerPathPositions
 }
 
 // visit walks the AST for a file and assigns hover text and a moniker path to interesting positions.
@@ -101,53 +90,46 @@ func (l *Preloader) MonikerPath(p *packages.Package, position token.Pos) []strin
 // A position's moniker path is the name of the object prefixed with the names of the containers that
 // enclose that position.
 func visit(
-	node ast.Node,
-	definitionPositions []token.Pos,
-	fieldPositions map[token.Pos]struct{},
-	hoverTextMap map[token.Pos]nodePath,
-	monikerPathMap map[token.Pos][]string,
-	path nodePath,
-	monikerPath []string,
+	node ast.Node, // Current node
+	hoverTextPositions map[token.Pos]struct{}, // Positions for which to assign hover text
+	monikerPathPositions map[token.Pos]struct{}, // Positions for which to assign moniker paths
+	hoverTextMap map[token.Pos]ast.Node, // Target hover text map
+	monikerPathMap map[token.Pos][]string, // Target moniker path map
+	nodeWithHoverText ast.Node, // The ancestor node with non-empty hover text (if any)
+	monikerPath []string, // The moniker path constructed up to this node
 ) {
-	newPath := updateNodePath(path, node)
-	newMonikerPath := updateMonikerPath(monikerPath, node)
-	start := sort.Search(len(definitionPositions), func(i int) bool {
-		return definitionPositions[i] >= node.Pos()
-	})
-
-	end := start
-	for end < len(definitionPositions) && definitionPositions[end] <= node.End() {
-		end++
+	if canExtractHoverText(node) {
+		// If we have hover text replace whatever ancestor node we might
+		// have. We have more relevant text on this node, so just use that.
+		nodeWithHoverText = node
 	}
+
+	// If we're a field or type, update our moniker path
+	newMonikerPath := updateMonikerPath(monikerPath, node)
 
 	for _, child := range childrenOf(node) {
-		visit(child, definitionPositions[start:end], fieldPositions, hoverTextMap, monikerPathMap, newPath, newMonikerPath)
+		visit(
+			child,
+			hoverTextPositions,
+			monikerPathPositions,
+			hoverTextMap,
+			monikerPathMap,
+			chooseNodeWithHoverText(node, child),
+			newMonikerPath,
+		)
 	}
 
-	for i := start; i < end; i++ {
-		if _, ok := hoverTextMap[definitionPositions[i]]; !ok {
-			hoverTextMap[definitionPositions[i]] = newPath
-		}
+	if _, ok := hoverTextPositions[node.Pos()]; ok {
+		hoverTextMap[node.Pos()] = nodeWithHoverText
 	}
-
-	if _, ok := fieldPositions[node.Pos()]; ok {
+	if _, ok := monikerPathPositions[node.Pos()]; ok {
 		monikerPathMap[node.Pos()] = newMonikerPath
 	}
 }
 
-// updateNodePath creates a array composed of the previous path plus the given node. This function
-// does not modify the input array.
-func updateNodePath(path nodePath, node ast.Node) nodePath {
-	newPath := nodePath{node}
-	for i := 0; i < nodePathLength-1; i++ {
-		newPath[i+1] = path[i]
-	}
-	return newPath
-}
-
-// updateMonikerPath appends to the given slice the name of the node if it has a name that
-// can uniquely identify it along a path of nodes to the root of the file. Otherwise, the
-// given slice is returned unchanged. This function does not modify the input slice.
+// updateMonikerPath returns the given slice plus the name of the given node if it has a name that
+// can uniquely identify it along a path of nodes to the root of the file (an enclosing type).
+// Otherwise, the given slice is returned unchanged. This function does not modify the input slice.
 func updateMonikerPath(monikerPath []string, node ast.Node) []string {
 	switch q := node.(type) {
 	case *ast.Field:
@@ -189,40 +171,94 @@ func childrenOf(n ast.Node) (children []ast.Node) {
 	return children
 }
 
-// commentsFromPath returns the first non-empty comment attached to a node in the given path.
-func commentsFromPath(path nodePath) (comment string) {
-	for _, node := range path {
-		if comment != "" || node == nil {
-			break
-		}
-
-		switch v := node.(type) {
-		case *ast.Field:
-			// Concat associated documentation with any inline comments
-			comment = joinNonEmpty(v.Doc.Text(), v.Comment.Text())
-		case *ast.FuncDecl:
-			comment = v.Doc.Text()
-		case *ast.GenDecl:
-			comment = v.Doc.Text()
-		case *ast.TypeSpec:
-			comment = v.Doc.Text()
-		case *ast.ValueSpec:
-			comment = v.Doc.Text()
-		}
+// isField returns true if the given object is a field.
+func isField(obj types.Object) bool {
+	if v, ok := obj.(*types.Var); ok && v.IsField() {
+		return true
 	}
-
-	return comment
+	return false
 }
 
-// joinNonEmpty removes empty strings from the input list and joins the remaining values
-// with a newline.
-func joinNonEmpty(values ...string) string {
-	var parts []string
-	for _, value := range values {
-		if value != "" {
-			parts = append(parts, value)
+// shouldHaveHoverText returns true if the object is a type for which we should store hover text. This
+// is similar but distinct from the set of types from which we _extract_ hover text. See canExtractHoverText
+// for those types. This function returns true for the set of objects for which we actually call the methods
+// findHoverContents  or findExternalHoverContents (see hover.go).
+func shouldHaveHoverText(obj types.Object) bool {
+	switch obj.(type) {
+	case *types.Const:
+		return true
+	case *types.Func:
+		return true
+	case *types.Label:
+		return true
+	case *types.TypeName:
+		return true
+	case *types.Var:
+		return true
+	}
+
+	return false
+}
+
+// extractHoverText returns the comments attached to the given node.
+func extractHoverText(node ast.Node) string {
+	switch v := node.(type) {
+	case *ast.FuncDecl:
+		return v.Doc.Text()
+	case *ast.GenDecl:
+		return v.Doc.Text()
+	case *ast.TypeSpec:
+		return v.Doc.Text()
+	case *ast.ValueSpec:
+		return v.Doc.Text()
+	case *ast.Field:
+		return strings.TrimSpace(v.Doc.Text() + "\n" + v.Comment.Text())
+	}
+
+	return ""
+}
+
+// canExtractHoverText returns true if the node has non-empty comments extractable by extractHoverText.
+func canExtractHoverText(node ast.Node) bool {
+	switch v := node.(type) {
+	case *ast.FuncDecl:
+		return !commentGroupsEmpty(v.Doc)
+	case *ast.GenDecl:
+		return !commentGroupsEmpty(v.Doc)
+	case *ast.TypeSpec:
+		return !commentGroupsEmpty(v.Doc)
+	case *ast.ValueSpec:
+		return !commentGroupsEmpty(v.Doc)
+	case *ast.Field:
+		return !commentGroupsEmpty(v.Doc, v.Comment)
+	}
+
+	return false
+}
+
+// commentGroupsEmpty returns true if all of the given comments groups are empty.
+func commentGroupsEmpty(gs ...*ast.CommentGroup) bool {
+	for _, g := range gs {
+		if g != nil && len(g.List) > 0 {
+			return false
 		}
 	}
 
-	return strings.Join(parts, "\n")
+	return true
+}
+
+// chooseNodeWithHoverText returns the parent node if the relationship between the parent and child is
+// one in which comments can be reasonably shared. This will return a nil node for most relationships,
+// except things like (1) FuncDecl -> Ident, in which case we want to store the function's comment
+// in the ident, or (2) GenDecl -> TypeSpec, in which case we want to store the generic declaration's
+// comments if the type pnode doesn't have any directly attached to it.
+func chooseNodeWithHoverText(parent, child ast.Node) ast.Node {
+	if _, ok := parent.(*ast.GenDecl); ok {
+		return parent
+	}
+	if _, ok := child.(*ast.Ident); ok {
+		return parent
+	}
+
+	return nil
 }

--- a/internal/testdata/data.go
+++ b/internal/testdata/data.go
@@ -12,27 +12,31 @@ type TestInterface interface {
 	Do(ctx context.Context, data string) (score int, _ error)
 }
 
-// TestStruct is a struct used for testing.
-type TestStruct struct {
-	// SimpleA docs
-	SimpleA int
-	// SimpleB docs
-	SimpleB int
-	// SimpleC docs
-	SimpleC int
+type (
+	// TestStruct is a struct used for testing.
+	TestStruct struct {
+		// SimpleA docs
+		SimpleA int
+		// SimpleB docs
+		SimpleB int
+		// SimpleC docs
+		SimpleC int
 
-	FieldWithTag           string `json:"tag"`
-	FieldWithAnonymousType struct {
-		NestedA string
-		NestedB string
-		NestedC string
+		FieldWithTag           string `json:"tag"`
+		FieldWithAnonymousType struct {
+			NestedA string
+			NestedB string
+			// NestedC docs
+			NestedC string
+		}
+
+		EmptyStructField struct{}
 	}
 
-	EmptyStructField struct{}
-}
+	TestEmptyStruct struct{}
+)
 
-type TestEmptyStruct struct{}
-
+// Score is just a hardcoded number.
 const Score = uint64(42)
 const secretScore = secret.SecretScore
 

--- a/internal/testdata/parallel.go
+++ b/internal/testdata/parallel.go
@@ -19,9 +19,8 @@ func Parallel(ctx context.Context, fns ...ParallelizableFunc) error {
 		wg.Add(1)
 
 		go func(fn ParallelizableFunc) {
-			defer wg.Done()
-
 			errs <- fn(ctx)
+			wg.Done()
 		}(fn)
 	}
 


### PR DESCRIPTION
Change the semantics of the preloader's hoverText map. Previously this would contain the last three ancestors for every node. Now this contains _one_ ancestor node of reach _relevant_ node. This has two savings: (1) We are only storing keys of relevant nodes rather than every definition, and (2) we are now storing only one object per key instead of an array.

This change works because we were only iterating a _path_ of nodes previously to get around a few edge case: 

Comments attached to GenDecl instead of TypeSpec:

```
// comment
type Something struct {}
```

vs

```
type (
    // comment
    Something struct {}
)
```

Comments attached to functions but not their identifiers:

```
// comment
func Something() error {
    // ...
}
```

Instead now we store the _exact_ ancestor node we would have found non-empty comments for.