### PR TITLE
Fix typestring reformatting

### DIFF
--- a/internal/indexer/typestring.go
+++ b/internal/indexer/typestring.go
@@ -56,8 +56,31 @@ func formatTypeExtra(obj *types.TypeName) string {
 	depth := 0
 	buf := bytes.NewBuffer(make([]byte, 0, len(extra)))
 
+outer:
 	for i := 0; i < len(extra); i++ {
 		switch extra[i] {
+		case '"':
+			for j := i + 1; j < len(extra); j++ {
+				if extra[j] == '\\' {
+					// skip over escaped characters
+					j++
+					continue
+				}
+
+				if extra[j] == '"' {
+					// found non-escaped ending quote
+					// write entire string unchanged, then skip to this
+					// character adn continue the outer loop, which will
+					// start the next iteration on the following character
+					buf.WriteString(extra[i : j+1])
+					i = j
+					continue outer
+				}
+			}
+
+			// note: we should never get down here otherwise
+			// there is some illegal output from types.TypeString.
+
 		case ';':
 			buf.WriteString("\n")
 			buf.WriteString(strings.Repeat(indent, depth))

--- a/internal/indexer/typestring_test.go
+++ b/internal/indexer/typestring_test.go
@@ -90,3 +90,22 @@ func TestTypeStringEmptyStruct(t *testing.T) {
 		t.Errorf("unexpected extra (-want +got): %s", diff)
 	}
 }
+
+func TestStructTagRegression(t *testing.T) {
+	_, f := findDefinitionByName(t, getTestPackages(t), "StructTagRegression")
+
+	signature, extra := typeString(f)
+	if signature != "type StructTagRegression struct" {
+		t.Errorf("unexpected type string. want=%q have=%q", "type StructTagRegression struct", signature)
+	}
+
+	expectedExtra := strings.TrimSpace(stripIndent(`
+		struct {
+		    Value int "key:\",range=[:}\""
+		}
+	`))
+
+	if diff := cmp.Diff(expectedExtra, extra); diff != "" {
+		t.Errorf("unexpected extra (-want +got): %s", diff)
+	}
+}

--- a/internal/testdata/data.go
+++ b/internal/testdata/data.go
@@ -44,3 +44,11 @@ const secretScore = secret.SecretScore
 func (ts *TestStruct) Doer(ctx context.Context, data string) (score int, err error) {
 	return Score, nil
 }
+
+// StructTagRegression is a struct that caused panic in the wild. Added here to
+// support a regression test.
+//
+// See https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272.
+type StructTagRegression struct {
+	Value int `key:",range=[:}"`
+}


### PR DESCRIPTION
We did not correctly handle struct tags including bracket characters. This results in a panic due to a negative-length string.Repeat parameter.