### PR TITLE
Replace "'" with "" as intended

### DIFF
--- a/internal/indexer/hover.go
+++ b/internal/indexer/hover.go
@@ -135,5 +135,5 @@ func extractPackageDocstring(p *packages.Package) string {
 		}
 	}
 
-	return "'"
+	return ""
 }


### PR DESCRIPTION
Packages without docs now have the docs `'` which isn't helpful.