### PR TITLE
Index symbolic variable in type switch header

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -247,9 +247,31 @@ func (i *Indexer) indexDefinitions() {
 
 // indexDefinitionsForPackage emits data for each definition within the given package.
 func (i *Indexer) indexDefinitionsForPackage(p *packages.Package) {
-	for _, obj := range p.TypesInfo.Defs {
+	// Create a map of implicit case clause objects by their position. Note that there is an
+	// implicit object for each case clause of a type switch (including default), and they all
+	// share the same position. This creates a map with one arbitrarily chosen argument for
+	// each distinct type switch.
+	caseClauses := map[token.Pos]types.Object{}
+	for node, obj := range p.TypesInfo.Implicits {
+		if _, ok := node.(*ast.CaseClause); ok {
+			caseClauses[obj.Pos()] = obj
+		}
+	}
+
+	for ident, obj := range p.TypesInfo.Defs {
+		typeSwitchHeader := false
 		if obj == nil {
-			continue
+			// The definitions map contains nil objects for symbolic variables t in t := x.(type)
+			// of type switch headers. In these cases we select an arbitrary case clause for the
+			// same type switch to index the definition. We mark this object as a typeSwitchHeader
+			// so that it can distinguished from other definitions with non-nil objects.
+			caseClause, ok := caseClauses[ident.Pos()]
+			if !ok {
+				continue
+			}
+
+			obj = caseClause
+			typeSwitchHeader = true
 		}
 
 		pos, d, ok := i.positionAndDocument(p, obj.Pos())
@@ -257,7 +279,7 @@ func (i *Indexer) indexDefinitionsForPackage(p *packages.Package) {
 			continue
 		}
 
-		rangeID := i.indexDefinition(p, pos.Filename, d, pos, obj)
+		rangeID := i.indexDefinition(p, pos.Filename, d, pos, obj, typeSwitchHeader)
 
 		i.stripedMutex.LockKey(pos.Filename)
 		i.ranges[pos.Filename][pos.Offset] = rangeID
@@ -309,14 +331,7 @@ func (i *Indexer) markRange(pos token.Position) bool {
 }
 
 // indexDefinition emits data for the given definition object.
-func (i *Indexer) indexDefinition(p *packages.Package, filename string, document *DocumentInfo, pos token.Position, obj types.Object) uint64 {
-	// Create a hover result vertex and cache the result identifier keyed by the definition location.
-	// Caching this gives us a big win for package documentation, which is likely to be large and is
-	// repeated at each import and selector within referenced files.
-	hoverResultID := i.makeCachedHoverResult(nil, obj, func() []protocol.MarkedString {
-		return findHoverContents(i.packageDataCache, i.packages, p, obj)
-	})
-
+func (i *Indexer) indexDefinition(p *packages.Package, filename string, document *DocumentInfo, pos token.Position, obj types.Object, typeSwitchHeader bool) uint64 {
 	rangeID := i.emitter.EmitRange(rangeForObject(obj, pos))
 	resultSetID := i.emitter.EmitResultSet()
 	defResultID := i.emitter.EmitDefinitionResult()
@@ -324,7 +339,19 @@ func (i *Indexer) indexDefinition(p *packages.Package, filename string, document
 	_ = i.emitter.EmitNext(rangeID, resultSetID)
 	_ = i.emitter.EmitTextDocumentDefinition(resultSetID, defResultID)
 	_ = i.emitter.EmitItem(defResultID, []uint64{rangeID}, document.DocumentID)
-	_ = i.emitter.EmitTextDocumentHover(resultSetID, hoverResultID)
+
+	if typeSwitchHeader {
+		// TODO(efritz) - not sure how to document a type switch header symbolic variable
+		// I'd like to somehow keep the type string of the RHS, but I'm not yet sure how
+		// to resolve that data given what we have.
+	} else {
+		// Create a hover result vertex and cache the result identifier keyed by the definition location.
+		// Caching this gives us a big win for package documentation, which is likely to be large and is
+		// repeated at each import and selector within referenced files.
+		_ = i.emitter.EmitTextDocumentHover(resultSetID, i.makeCachedHoverResult(nil, obj, func() []protocol.MarkedString {
+			return findHoverContents(i.packageDataCache, i.packages, p, obj)
+		}))
+	}
 
 	if _, ok := obj.(*types.PkgName); ok {
 		i.emitImportMoniker(resultSetID, p, obj)
@@ -339,6 +366,7 @@ func (i *Indexer) indexDefinition(p *packages.Package, filename string, document
 		RangeID:           rangeID,
 		ResultSetID:       resultSetID,
 		ReferenceRangeIDs: map[uint64][]uint64{},
+		TypeSwitchHeader:  typeSwitchHeader,
 	})
 
 	return rangeID
@@ -415,7 +443,7 @@ func (i *Indexer) indexReferencesForPackage(p *packages.Package) {
 // indexReference emits data for the given reference object.
 func (i *Indexer) indexReference(p *packages.Package, document *DocumentInfo, pos token.Position, definitionObj types.Object) (uint64, bool) {
 	if def := i.getDefinitionInfo(definitionObj); def != nil {
-		return i.indexReferenceToDefinition(document, pos, definitionObj, def)
+		return i.indexReferenceToDefinition(p, document, pos, definitionObj, def)
 	}
 
 	return i.indexReferenceToExternalDefinition(p, document, pos, definitionObj)
@@ -445,13 +473,23 @@ func (i *Indexer) getDefinitionInfo(obj types.Object) *DefinitionInfo {
 
 // indexReferenceToDefinition emits data for the given reference object that is defined within
 // an index target package.
-func (i *Indexer) indexReferenceToDefinition(document *DocumentInfo, pos token.Position, definitionObj types.Object, d *DefinitionInfo) (uint64, bool) {
+func (i *Indexer) indexReferenceToDefinition(p *packages.Package, document *DocumentInfo, pos token.Position, definitionObj types.Object, d *DefinitionInfo) (uint64, bool) {
 	rangeID := i.ensureRangeFor(pos, definitionObj)
 	_ = i.emitter.EmitNext(rangeID, d.ResultSetID)
 
 	d.m.Lock()
 	d.ReferenceRangeIDs[document.DocumentID] = append(d.ReferenceRangeIDs[document.DocumentID], rangeID)
 	d.m.Unlock()
+
+	if d.TypeSwitchHeader {
+		// Attache a hover text result _directly_ to the given range so that it "overwrites" the
+		// hover result of the type switch header for this use. Each reference of such a variable
+		// will need a more specific hover text, as the type of the variable is refined in the body
+		// of case clauses of the type switch.
+		_ = i.emitter.EmitTextDocumentHover(rangeID, i.makeCachedHoverResult(nil, definitionObj, func() []protocol.MarkedString {
+			return findHoverContents(i.packageDataCache, i.packages, p, definitionObj)
+		}))
+	}
 
 	return rangeID, true
 }

--- a/internal/indexer/info.go
+++ b/internal/indexer/info.go
@@ -32,5 +32,6 @@ type DefinitionInfo struct {
 	RangeID           uint64
 	ResultSetID       uint64
 	ReferenceRangeIDs map[uint64][]uint64
+	TypeSwitchHeader  bool
 	m                 sync.Mutex
 }

--- a/internal/testdata/typeswitch.go
+++ b/internal/testdata/typeswitch.go
@@ -1,0 +1,12 @@
+package testdata
+
+func Switch(interfaceValue interface{}) bool {
+	switch concreteValue := interfaceValue.(type) {
+	case int:
+		return concreteValue*3 > 10
+	case bool:
+		return !concreteValue
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
**Previously**: There is no definition for the symbolic variable in the type switch header, and each of the case clauses share _some_ arbitrary hover text that applies to one case clause correctly, but all the remaining clauses incorrectly. This is also a non-deterministic choice and may change if you index twice.

![Kapture 2020-09-04 at 12 17 22](https://user-images.githubusercontent.com/103087/92268864-c2e62300-eea8-11ea-9586-c3fbdb3fa3f7.gif)

**After this change**: We have the correct hover text for each case clause use, and each occurrence of the symbol variable are linked correctly via def/ref chains. The definition itself has no hover text (see TODO in PR code).

![Kapture 2020-09-04 at 12 18 09](https://user-images.githubusercontent.com/103087/92268866-c4afe680-eea8-11ea-823f-9cf53a9c7054.gif)

Closes https://github.com/sourcegraph/lsif-go/issues/117.

**Remaining work:**

- [ ] Figure out how to get hover text for definition
- [x] Write additional tests covering type switches