### PR TITLE
bump Go version to 1.16.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.14.x
+          go-version: 1.16.x
       - uses: azure/docker-login@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM sourcegraph/src-cli:3.17.1@sha256:3eff13f7b3e2e5294aa89f9386454c9ce49ffceac20b373eadd8206af66206d8 AS src-cli
 
-FROM golang:1.14-buster@sha256:71f35a85bbd89645bc9f95abe4da751958677d66094bebfa5d9a7fcaadc8fa27
+FROM golang:1.16.2-buster@sha256:5a6302e91acb152050d661c9a081a535978c629225225ed91a8b979ad24aafcd
 
 COPY --from=src-cli /usr/bin/src /usr/bin/
 COPY lsif-go /usr/bin/

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -29,7 +29,7 @@ func TestIndexer(t *testing.T) {
 	}
 
 	t.Run("check Parallel function hover text", func(t *testing.T) {
-		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 13, 5)
+		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 14, 5)
 		if !ok {
 			t.Fatalf("could not find target range")
 		}
@@ -83,7 +83,7 @@ func TestIndexer(t *testing.T) {
 	})
 
 	t.Run("check errs definition", func(t *testing.T) {
-		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 21, 3)
+		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 22, 3)
 		if !ok {
 			t.Fatalf("could not find target range")
 		}
@@ -93,11 +93,11 @@ func TestIndexer(t *testing.T) {
 			t.Fatalf("incorrect definition count. want=%d have=%d", 1, len(definitions))
 		}
 
-		compareRange(t, definitions[0], 15, 1, 15, 5)
+		compareRange(t, definitions[0], 16, 1, 16, 5)
 	})
 
 	t.Run("check wg references", func(t *testing.T) {
-		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 26, 1)
+		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "parallel.go"), 27, 1)
 		if !ok {
 			t.Fatalf("could not find target range")
 		}
@@ -109,10 +109,10 @@ func TestIndexer(t *testing.T) {
 
 		sort.Slice(references, func(i, j int) bool { return references[i].Start.Line < references[j].Start.Line })
 
-		compareRange(t, references[0], 14, 5, 14, 7) // var wg sync.WaitGroup
-		compareRange(t, references[1], 18, 2, 18, 4) // wg.Add(1)
-		compareRange(t, references[2], 22, 3, 22, 5) // wg.Done()
-		compareRange(t, references[3], 26, 1, 26, 3) // wg.Wait()
+		compareRange(t, references[0], 15, 5, 15, 7) // var wg sync.WaitGroup
+		compareRange(t, references[1], 19, 2, 19, 4) // wg.Add(1)
+		compareRange(t, references[2], 23, 3, 23, 5) // wg.Done()
+		compareRange(t, references[3], 27, 1, 27, 3) // wg.Wait()
 	})
 
 	t.Run("check NestedB monikers", func(t *testing.T) {

--- a/internal/testdata/parallel.go
+++ b/internal/testdata/parallel.go
@@ -11,6 +11,7 @@ type ParallelizableFunc func(ctx context.Context) error
 
 // Parallel invokes each of the given parallelizable functions in their own goroutines and
 // returns the first error to occur. This method will block until all goroutines have returned.
+//go:noescape
 func Parallel(ctx context.Context, fns ...ParallelizableFunc) error {
 	var wg sync.WaitGroup
 	errs := make(chan error, len(fns))


### PR DESCRIPTION
Closes #132 

I see lsif-go was dropped from 1.15 to 1.14 at one stage. Does this hinder us moving to 1.16? 