### PR TITLE
Spike adding deprecations to document symbols

### DIFF
--- a/internal/indexer/protocol.go
+++ b/internal/indexer/protocol.go
@@ -2,8 +2,10 @@ package indexer
 
 import (
 	"bytes"
+	"go/ast"
 	"go/token"
 	"go/types"
+	"golang.org/x/tools/go/packages"
 	"strings"
 
 	doc "github.com/slimsag/godocmd"
@@ -11,6 +13,15 @@ import (
 )
 
 const languageGo = "go"
+
+var objKindToSymbolKind = map[ast.ObjKind]protocol.SymbolKind{
+	ast.Pkg: protocol.Package,
+	ast.Con: protocol.Constant,
+	ast.Typ: protocol.Class, // Based on LLVM LSP implementation; no type alias in spec
+	ast.Var: protocol.Variable,
+	ast.Fun: protocol.Function,
+	//ast.Lbl: protocol.:noidea: // No label in spec
+}
 
 // rangeForObject transforms the position of the given object (1-indexed) into an LSP range
 // (0-indexed). If the object is a quoted package name, the leading and trailing quotes are
@@ -28,6 +39,66 @@ func rangeForObject(obj types.Object, pos token.Position) (protocol.Pos, protoco
 	start := protocol.Pos{Line: line, Character: column + adjustment}
 	end := protocol.Pos{Line: line, Character: column + n - adjustment}
 	return start, end
+}
+
+func tagForObject(p *packages.Package, obj *ast.Object, rangeType string, commentMap ast.CommentMap, start, end protocol.Pos) *protocol.RangeTag {
+	kind, ok := objKindToSymbolKind[obj.Kind]
+	if !ok {
+		return nil
+	}
+
+	deprecated := false
+
+	// Since we're just looking at definitions right now, we assume that Decl
+	// will be defined or that we can kind of just ignore comments.
+	if obj.Decl != nil {
+		commentGroups := commentMap[obj.Decl.(ast.Node)]
+		for _, commentGroup := range commentGroups {
+			lines := strings.Split(commentGroup.Text(), "\n")
+			for _, line := range lines {
+				if strings.HasPrefix(line, "Deprecated: ") {
+					deprecated = true
+					break
+				}
+			}
+
+			// The tag range wants us to include comments, so we adjust if the
+			// comments fall outside the current range.
+			commentStart := p.Fset.Position(commentGroup.Pos())
+			startLine := commentStart.Line - 1
+			startColumn := commentStart.Column - 1
+			if startLine < start.Line || (startLine == start.Line && startColumn < start.Character) {
+				start.Line = startLine
+				start.Character = startColumn
+			}
+
+			commentEnd := p.Fset.Position(commentGroup.End())
+			endLine := commentEnd.Line - 1
+			endColumn := commentEnd.Column - 1
+			if endLine > end.Line || (endLine == end.Line && endColumn > end.Character) {
+				end.Line = endLine
+				end.Character = endColumn
+			}
+		}
+	}
+
+	fullRange := &protocol.RangeData{
+		Start: start,
+		End: end,
+	}
+
+	tag := &protocol.RangeTag{
+		Type: rangeType,
+		Text: obj.Name,
+		Kind: kind,
+		FullRange: fullRange,
+	}
+
+	if deprecated {
+		tag.Tags = []protocol.SymbolTag{protocol.Deprecated}
+	}
+
+	return tag
 }
 
 // toMarkedString creates a protocol.MarkedString object from the given content. The signature


### PR DESCRIPTION
While the LSP and LSIF support marking definitions as deprecated, and sourcegraph appears capable of ingesting this data, this is currently not supported by the go indexer.

This PR is not intended for merge; instead, it is meant to provide a proof of concept and forum for discussion. It has several serious shortcomings:
- Tags are only emitted for top-level definitions (sufficient for deprecation marking but not for the general case)
  Because the indexer uses `p.TypesInfo` instead of walking the AST, it's unable (as far as I can see) to access the AST to get the necessary information for more tightly-scoped definitions without an ~O(n) tree walk every time we need to look up a definition. I think the AST would be usable for the indexer, but it seems like a sizeable refactor.
- Label definitions are ignored for tagging purposes due to a lack of appropriate `SymbolKind` in the spec; type aliases are not ignored, but the mapping is less than ideal
  https://github.com/microsoft/language-server-protocol/issues/344 gathers some requested `SymbolKind` extensions (including `typeAlias`), but also indicates that the team isn't really looking to expand that list at present.
- It's a spike; it ain't pretty
  Okay, this one is easier to solve.