### PR TITLE
 indexer: prepare to index documentSymbols (do not index duplicate definitions)

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -355,7 +355,7 @@ func (i *Indexer) indexDefinitionsForPackage(p *packages.Package) {
 		}
 
 		pos, d, ok := i.positionAndDocument(p, obj.Pos())
-		if !ok || !i.markRange(pos) {
+		if !ok {
 			continue
 		}
 
@@ -387,27 +387,6 @@ func (i *Indexer) positionAndDocument(p *packages.Package, pos token.Pos) (token
 	}
 
 	return position, d, true
-}
-
-// markRange sets an empty range identifier in the ranges map for the given position.
-// If a  range for this identifier has already been marked, this method returns false.
-func (i *Indexer) markRange(pos token.Position) bool {
-	i.stripedMutex.RLockKey(pos.Filename)
-	_, ok := i.ranges[pos.Filename][pos.Offset]
-	i.stripedMutex.RUnlockKey(pos.Filename)
-	if ok {
-		return false
-	}
-
-	i.stripedMutex.LockKey(pos.Filename)
-	defer i.stripedMutex.UnlockKey(pos.Filename)
-
-	if _, ok := i.ranges[pos.Filename][pos.Offset]; ok {
-		return false
-	}
-
-	i.ranges[pos.Filename][pos.Offset] = 0 // placeholder
-	return true
 }
 
 // indexDefinition emits data for the given definition object.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -412,7 +412,9 @@ func (i *Indexer) markRange(pos token.Position) bool {
 
 // indexDefinition emits data for the given definition object.
 func (i *Indexer) indexDefinition(p *packages.Package, filename string, document *DocumentInfo, pos token.Position, obj types.Object, typeSwitchHeader bool, ident *ast.Ident) uint64 {
-	rangeID := i.emitter.EmitRange(rangeForObject(obj, pos))
+	// Ensure the range exists, but don't emit a new one as it might already exist due to another
+	// phase of indexing (such as symbols) having emitted the range.
+	rangeID := i.ensureRangeFor(pos, obj)
 	resultSetID := i.emitter.EmitResultSet()
 	defResultID := i.emitter.EmitDefinitionResult()
 

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -36,13 +36,14 @@ type Indexer struct {
 	vars    map[interface{}]*DefinitionInfo // position -> info
 
 	// LSIF data cache
-	documents             map[string]*DocumentInfo  // filename -> info
-	ranges                map[string]map[int]uint64 // filename -> offset -> rangeID
-	hoverResultCache      map[string]uint64         // cache key -> hoverResultID
-	packageInformationIDs map[string]uint64         // name -> packageInformationID
-	packageDataCache      *PackageDataCache         // hover text and moniker path cache
-	packages              []*packages.Package       // index target packages
-	projectID             uint64                    // project vertex identifier
+	documents             map[string]*DocumentInfo    // filename -> info
+	ranges                map[string]map[int]uint64   // filename -> offset -> rangeID
+	defined               map[string]map[int]struct{} // set of defined ranges (filename, offset)
+	hoverResultCache      map[string]uint64           // cache key -> hoverResultID
+	packageInformationIDs map[string]uint64           // name -> packageInformationID
+	packageDataCache      *PackageDataCache           // hover text and moniker path cache
+	packages              []*packages.Package         // index target packages
+	projectID             uint64                      // project vertex identifier
 	packagesByFile        map[string][]*packages.Package
 
 	constsMutex                sync.Mutex
@@ -84,6 +85,7 @@ func New(
 		vars:                  map[interface{}]*DefinitionInfo{},
 		documents:             map[string]*DocumentInfo{},
 		ranges:                map[string]map[int]uint64{},
+		defined:               map[string]map[int]struct{}{},
 		hoverResultCache:      map[string]uint64{},
 		packageInformationIDs: map[string]uint64{},
 		packageDataCache:      packageDataCache,
@@ -264,6 +266,7 @@ func (i *Indexer) emitDocument(filename string) {
 	documentID := i.emitter.EmitDocument(languageGo, filename)
 	i.documents[filename] = &DocumentInfo{DocumentID: documentID}
 	i.ranges[filename] = map[int]uint64{}
+	i.defined[filename] = map[int]struct{}{}
 }
 
 // addImports modifies the definitions map of each file to include entries for import statements so
@@ -358,6 +361,13 @@ func (i *Indexer) indexDefinitionsForPackage(p *packages.Package) {
 		if !ok {
 			continue
 		}
+		if !i.markRange(pos) {
+			// This performs a quick assignment to a map that will ensure that
+			// we don't race against another routine indexing the same definition
+			// reachable from another dataflow path through the indexer. If we
+			// lose a race, we'll just bail out and look at the next definition.
+			continue
+		}
 
 		rangeID := i.indexDefinition(p, pos.Filename, d, pos, obj, typeSwitchHeader, ident)
 
@@ -387,6 +397,27 @@ func (i *Indexer) positionAndDocument(p *packages.Package, pos token.Pos) (token
 	}
 
 	return position, d, true
+}
+
+// markRange sets a zero-size struct into a map for the given position. If this position
+// has already been marked, this method returns false.
+func (i *Indexer) markRange(pos token.Position) bool {
+	i.stripedMutex.RLockKey(pos.Filename)
+	_, ok := i.defined[pos.Filename][pos.Offset]
+	i.stripedMutex.RUnlockKey(pos.Filename)
+	if ok {
+		return false
+	}
+
+	i.stripedMutex.LockKey(pos.Filename)
+	defer i.stripedMutex.UnlockKey(pos.Filename)
+
+	if _, ok := i.defined[pos.Filename][pos.Offset]; ok {
+		return false
+	}
+
+	i.defined[pos.Filename][pos.Offset] = struct{}{}
+	return true
 }
 
 // indexDefinition emits data for the given definition object.


### PR DESCRIPTION
After spending all day debugging, I think I finally understand what is going on here and answered my own issue :) PTAL @efritz 

Helps https://github.com/sourcegraph/sourcegraph/issues/19591

## The first commit

This prepares the indexer to index `textDocument/documentSymbols`. The problem
here is that indexing symbols involves emitting ranges for the symbol definitions,
and so does our existing indexing for `indexDefinition`. LSIF ranges cannot overlap
or be duplicative, so we must effectively make symbol and definition indexing work
together. The idea is that symbol indexing will emit ranges for the definitions it
encounters, and traditional definition indexing will merely reuse those or emit a
new range if needed.

At present, this causes all tests to fail due to the way we pre-emptively mark
a range for generation during definition indexing:

```
--- FAIL: TestIndexer (0.63s)
    --- FAIL: TestIndexer/check_Parallel_function_hover_text (0.00s)
        indexer_test.go:35: could not find target range
    --- FAIL: TestIndexer/check_external_package_hover_text (0.00s)
        indexer_test.go:62: could not find target range
    --- FAIL: TestIndexer/check_errs_definition (0.00s)
        indexer_test.go:94: incorrect definition count. want=1 have=0
    --- FAIL: TestIndexer/check_wg_references (0.00s)
        indexer_test.go:108: incorrect reference count. want=4 have=3
    --- FAIL: TestIndexer/check_NestedB_monikers (0.00s)
        indexer_test.go:122: could not find target range
    --- FAIL: TestIndexer/check_typeswitch (0.00s)
        indexer_test.go:143: could not find target range
    --- FAIL: TestIndexer/check_typealias (0.00s)
        indexer_test.go:209: could not find target range
    --- FAIL: TestIndexer/check_typealias_reference (0.00s)
        indexer_test.go:255: incorrection definition count. want=1 have=0
    --- FAIL: TestIndexer/check_typealias_anonymous_struct (0.00s)
        indexer_test.go:296: could not find target range
FAIL
FAIL	github.com/sourcegraph/lsif-go/internal/indexer	17.393s
FAIL
```

## The second commit

indexer: remove pre-emptive range marking for definitions

Prior to this change, we would pre-emptively "mark" a range for a definition
as being actively produced. This appears to have been because `indexDefinition`
would _always_ emit a new range, and this it was necessary to ensure that two
parallel definition indexing processes would not emit the same range.

Since my prior commit, however, `indexDefinition` only emits a new range if one
does not exist. So pre-emptive range marking is not required anymore.

This causes all tests to pass.

