### PR TITLE
Make markRange unobtrusive for document symbols

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -36,13 +36,14 @@ type Indexer struct {
 	vars    map[interface{}]*DefinitionInfo // position -> info
 
 	// LSIF data cache
-	documents             map[string]*DocumentInfo  // filename -> info
-	ranges                map[string]map[int]uint64 // filename -> offset -> rangeID
-	hoverResultCache      map[string]uint64         // cache key -> hoverResultID
-	packageInformationIDs map[string]uint64         // name -> packageInformationID
-	packageDataCache      *PackageDataCache         // hover text and moniker path cache
-	packages              []*packages.Package       // index target packages
-	projectID             uint64                    // project vertex identifier
+	documents             map[string]*DocumentInfo    // filename -> info
+	ranges                map[string]map[int]uint64   // filename -> offset -> rangeID
+	defined               map[string]map[int]struct{} // set of defined ranges (filename, offset)
+	hoverResultCache      map[string]uint64           // cache key -> hoverResultID
+	packageInformationIDs map[string]uint64           // name -> packageInformationID
+	packageDataCache      *PackageDataCache           // hover text and moniker path cache
+	packages              []*packages.Package         // index target packages
+	projectID             uint64                      // project vertex identifier
 	packagesByFile        map[string][]*packages.Package
 
 	constsMutex                sync.Mutex
@@ -84,6 +85,7 @@ func New(
 		vars:                  map[interface{}]*DefinitionInfo{},
 		documents:             map[string]*DocumentInfo{},
 		ranges:                map[string]map[int]uint64{},
+		defined:               map[string]map[int]struct{}{},
 		hoverResultCache:      map[string]uint64{},
 		packageInformationIDs: map[string]uint64{},
 		packageDataCache:      packageDataCache,
@@ -264,6 +266,7 @@ func (i *Indexer) emitDocument(filename string) {
 	documentID := i.emitter.EmitDocument(languageGo, filename)
 	i.documents[filename] = &DocumentInfo{DocumentID: documentID}
 	i.ranges[filename] = map[int]uint64{}
+	i.defined[filename] = map[int]struct{}{}
 }
 
 // addImports modifies the definitions map of each file to include entries for import statements so
@@ -358,6 +361,13 @@ func (i *Indexer) indexDefinitionsForPackage(p *packages.Package) {
 		if !ok {
 			continue
 		}
+		if !i.markRange(pos) {
+			// This performs a quick assignment to a map that will ensure that
+			// we don't race against another routine indexing the same definition
+			// reachable from another dataflow path through the indexer. If we
+			// lose a race, we'll just bail out and look at the next definition.
+			continue
+		}
 
 		rangeID := i.indexDefinition(p, pos.Filename, d, pos, obj, typeSwitchHeader, ident)
 
@@ -387,6 +397,27 @@ func (i *Indexer) positionAndDocument(p *packages.Package, pos token.Pos) (token
 	}
 
 	return position, d, true
+}
+
+// markRange sets a zero-size struct into a map for the given position. If this position
+// has already been marked, this method returns false.
+func (i *Indexer) markRange(pos token.Position) bool {
+	i.stripedMutex.RLockKey(pos.Filename)
+	_, ok := i.defined[pos.Filename][pos.Offset]
+	i.stripedMutex.RUnlockKey(pos.Filename)
+	if ok {
+		return false
+	}
+
+	i.stripedMutex.LockKey(pos.Filename)
+	defer i.stripedMutex.UnlockKey(pos.Filename)
+
+	if _, ok := i.defined[pos.Filename][pos.Offset]; ok {
+		return false
+	}
+
+	i.defined[pos.Filename][pos.Offset] = struct{}{}
+	return true
 }
 
 // indexDefinition emits data for the given definition object.


### PR DESCRIPTION
Ok so you were correct about what `markRange` was doing. It stops multiple definitions that are reachable from different packages from clobbering over each other while trying to make the canonical version of that range.

`ensureRangeFor` was an obvious substitute since it is also properly locking so that nothing can be double-assigned. However, that lock only protects the range vertex itself, and not some other relations that should have a certain uniqueness property.

Removing `markRange` totally will make it so that ranges get `n` result sets (directly attached) to the same unique range. Thus, there are possibly `n` ambiguous definition and result sets to choose from at query time (this is why it's disallowed by the spec).

See https://github.com/sourcegraph/sourcegraph/pull/19946 for a new validation pass to test this.

This PR combines both approaches. We'll only have one call to `indexDefinition` per symbol, but we don't need to write the range vertex if it already exists.

@slimsag 
Note that in future implementations that if you're creating any structure around a range that's used elsewhere (if you attach a result set, definition result, etc to it in the document symbols pass) you'll need to ensure that you don't create a second result set in `indexDefinition` (which assumes it's the first pass to construct that relationship).