### PR TITLE
Do not emit duplicate import moniker vertices

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -40,6 +40,7 @@ type Indexer struct {
 	ranges                map[string]map[int]uint64   // filename -> offset -> rangeID
 	defined               map[string]map[int]struct{} // set of defined ranges (filename, offset)
 	hoverResultCache      map[string]uint64           // cache key -> hoverResultID
+	importMonikerIDs      map[string]uint64           // identifier:packageInformationID -> monikerID
 	packageInformationIDs map[string]uint64           // name -> packageInformationID
 	packageDataCache      *PackageDataCache           // hover text and moniker path cache
 	packages              []*packages.Package         // index target packages
@@ -54,6 +55,7 @@ type Indexer struct {
 	varsMutex                  sync.Mutex
 	stripedMutex               *StripedMutex
 	hoverResultCacheMutex      sync.RWMutex
+	importMonikerIDsMutex      sync.RWMutex
 	packageInformationIDsMutex sync.RWMutex
 }
 
@@ -87,6 +89,7 @@ func New(
 		ranges:                map[string]map[int]uint64{},
 		defined:               map[string]map[int]struct{}{},
 		hoverResultCache:      map[string]uint64{},
+		importMonikerIDs:      map[string]uint64{},
 		packageInformationIDs: map[string]uint64{},
 		packageDataCache:      packageDataCache,
 		stripedMutex:          newStripedMutex(),

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -17,12 +17,19 @@ func (i *Indexer) emitExportMoniker(sourceID uint64, p *packages.Package, obj ty
 		return
 	}
 
-	i.addMonikers(
-		"export",
-		strings.Trim(fmt.Sprintf("%s:%s", monikerPackage(obj), monikerIdentifier(i.packageDataCache, p, obj)), ":"),
-		sourceID,
-		i.ensurePackageInformation(i.moduleName, i.moduleVersion),
-	)
+	// If this is a package reference, remove the trailing `:`
+	monikerIdentifier := fmt.Sprintf("%s:%s", monikerPackage(obj), monikerIdentifier(i.packageDataCache, p, obj))
+	monikerIdentifier = strings.Trim(monikerIdentifier, ":")
+
+	// Lazily emit package information vertex
+	packageInformationID := i.ensurePackageInformation(i.moduleName, i.moduleVersion)
+
+	// Emit moniker
+	monikerID := i.emitter.EmitMoniker("export", "gomod", monikerIdentifier)
+
+	// Attach package information to moniker, and moniker to source element
+	_ = i.emitter.EmitPackageInformationEdge(monikerID, packageInformationID)
+	_ = i.emitter.EmitMonikerEdge(sourceID, monikerID)
 }
 
 // emitImportMoniker emits an import moniker for the given object linked to the given source
@@ -33,16 +40,24 @@ func (i *Indexer) emitImportMoniker(sourceID uint64, p *packages.Package, obj ty
 	pkg := monikerPackage(obj)
 
 	for _, moduleName := range packagePrefixes(pkg) {
-		if moduleVersion, ok := i.dependencies[moduleName]; ok {
-			i.addMonikers(
-				"import",
-				strings.Trim(fmt.Sprintf("%s:%s", pkg, monikerIdentifier(i.packageDataCache, p, obj)), ":"),
-				sourceID,
-				i.ensurePackageInformation(moduleName, moduleVersion),
-			)
-
-			break
+		version, ok := i.dependencies[moduleName]
+		if !ok {
+			continue
 		}
+
+		// If this is a package reference, remove the trailing `:`
+		monikerIdentifier := fmt.Sprintf("%s:%s", pkg, monikerIdentifier(i.packageDataCache, p, obj))
+		monikerIdentifier = strings.Trim(monikerIdentifier, ":")
+
+		// Lazily emit package information and moniker vertices
+		packageInformationID := i.ensurePackageInformation(moduleName, version)
+		monikerID := i.ensureImportMoniker(monikerIdentifier, packageInformationID)
+
+		// Attach moniker to source element
+		_ = i.emitter.EmitMonikerEdge(sourceID, monikerID)
+
+		// Stop after first match
+		break
 	}
 }
 
@@ -60,8 +75,8 @@ func packagePrefixes(packageName string) []string {
 }
 
 // ensurePackageInformation returns the identifier of a package information vertex with the
-// give name and version. A vertex will be emitted only if one with the same name not yet
-// been emitted.
+// give name and version. A vertex will be emitted only if one with the same name has not
+// yet been emitted.
 func (i *Indexer) ensurePackageInformation(name, version string) uint64 {
 	i.packageInformationIDsMutex.RLock()
 	packageInformationID, ok := i.packageInformationIDs[name]
@@ -82,13 +97,30 @@ func (i *Indexer) ensurePackageInformation(name, version string) uint64 {
 	return packageInformationID
 }
 
-// addMonikers emits a moniker vertex with the given identifier, an edge from the moniker
-// to the given package information vertex identifier, and an edge from the given source
-// identifier to the moniker vertex identifier.
-func (i *Indexer) addMonikers(kind, identifier string, sourceID, packageID uint64) {
-	monikerID := i.emitter.EmitMoniker(kind, "gomod", identifier)
-	_ = i.emitter.EmitPackageInformationEdge(monikerID, packageID)
-	_ = i.emitter.EmitMonikerEdge(sourceID, monikerID)
+// ensureImportMoniker returns the identifier of a moniker vertex with the give identifier
+// attached to teh given package information identifier. A vertex will be emitted only if
+// one with the same key has not yet been emitted.
+func (i *Indexer) ensureImportMoniker(identifier string, packageInformationID uint64) uint64 {
+	key := fmt.Sprintf("%s:%d", identifier, packageInformationID)
+
+	i.importMonikerIDsMutex.RLock()
+	monikerID, ok := i.importMonikerIDs[key]
+	i.importMonikerIDsMutex.RUnlock()
+	if ok {
+		return monikerID
+	}
+
+	i.importMonikerIDsMutex.Lock()
+	defer i.importMonikerIDsMutex.Unlock()
+
+	if monikerID, ok := i.importMonikerIDs[key]; ok {
+		return monikerID
+	}
+
+	monikerID = i.emitter.EmitMoniker("import", "gomod", identifier)
+	_ = i.emitter.EmitPackageInformationEdge(monikerID, packageInformationID)
+	i.importMonikerIDs[key] = monikerID
+	return monikerID
 }
 
 // monikerPackage returns the package prefix used to construct a unique moniker for the given object.

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -158,3 +158,21 @@ func TestMonikerIdentifierField(t *testing.T) {
 		t.Errorf("unexpected moniker identifier. want=%q have=%q", "TestStruct.FieldWithAnonymousType.NestedB", identifier)
 	}
 }
+
+func TestJoinMonikerParts(t *testing.T) {
+	testCases := []struct {
+		input    []string
+		expected string
+	}{
+		{input: []string{}, expected: ""},
+		{input: []string{"a"}, expected: "a"},
+		{input: []string{"a", "", "c"}, expected: "a:c"},
+		{input: []string{"a", "b", "c"}, expected: "a:b:c"},
+	}
+
+	for _, testCase := range testCases {
+		if actual := joinMonikerParts(testCase.input...); actual != testCase.expected {
+			t.Errorf("unexpected moniker identifier. want=%q have=%q", testCase.expected, actual)
+		}
+	}
+}

--- a/internal/indexer/moniker_test.go
+++ b/internal/indexer/moniker_test.go
@@ -17,6 +17,7 @@ func TestEmitExportMoniker(t *testing.T) {
 		moduleName:            "github.com/sourcegraph/lsif-go",
 		moduleVersion:         "3.14.159",
 		emitter:               writer.NewEmitter(w),
+		importMonikerIDs:      map[string]uint64{},
 		packageInformationIDs: map[string]uint64{},
 		stripedMutex:          newStripedMutex(),
 	}
@@ -65,6 +66,7 @@ func TestEmitImportMoniker(t *testing.T) {
 			"github.com/test/pkg/sub1": "1.2.3-deadbeef",
 		},
 		emitter:               writer.NewEmitter(w),
+		importMonikerIDs:      map[string]uint64{},
 		packageInformationIDs: map[string]uint64{},
 		stripedMutex:          newStripedMutex(),
 	}


### PR DESCRIPTION
This change adds a cache of import moniker ids that are hashed by their identifier and package information relation. If a single imported identifier is used frequently in a dependent package (common, such as a logger or util functions) then we can use the same vertex and package information edge for each range/resultSet instead of re-emitting each time it's used.

This should reduce index size on large projects.