### PR TITLE
Lookup cross-repo moniker path in correct package

### DIFF
--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -148,6 +148,10 @@ func monikerIdentifier(packageDataCache *PackageDataCache, p *packages.Package, 
 	}
 
 	if v, ok := obj.(*types.Var); ok && v.IsField() {
+		if target := p.Imports[obj.Pkg().Path()]; target != nil {
+			p = target
+		}
+
 		// Qualifiers for fields were populated as pre-load step so we do not need to traverse
 		// the AST path back up to the root to find the enclosing type specs and fields with an
 		// anonymous struct type.


### PR DESCRIPTION
We were previously emitting monikers equivalent to the imported *package* rather than the moniker for the field within that package. This was because we were using the package of the _use_ rather than the _definition_ to look up the cached moniker path calculated in an earlier phase.

This lookup was used correctly where we extract hover text, meaning that jump to definition/find refs were broken while hover text was likely correct for a lot of situations. This makes the lookups symmetric.