### PR TITLE
Use repo name as module name when go.mod is absent

### DIFF
--- a/internal/gomod/module_name.go
+++ b/internal/gomod/module_name.go
@@ -15,7 +15,7 @@ import (
 func ModuleName(dir, repo string) (string, error) {
 	if !isModule(dir) {
 		log.Println("WARNING: No go.mod file found in current directory.")
-		return "", nil
+		return resolveModuleName(repo, repo)
 	}
 
 	// Determine the declared name of the module


### PR DESCRIPTION
This uses the name of the remote repository as a module name when no go.mod file exists. This heuristically covers one-half of xrepo discoverability without explicit dependencies. We currently do nothing to choose versions for dependencies used in import paths and not explicit stated in a go.mod file (or something older like dep or glide). Maybe we'll add support for that later if dependency indexing on a larger scale requires it.

Note: this makes it so that we can index repos like [keegancsmith/sqlf ](https://github.com/keegancsmith/sqlf) without an explicit `go mod init` step.