### PR TITLE
Normalize module versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to `lsif-go` are documented in this file.
 
 Nothing yet.
 
+## Unreleased (v1.5.0) changes
+
+### Changed
+
+- :rotating_light: Changed package module version generation to make cross-index queries accurate. Cross-linking may not work with indexes created before v1.5.0. [#152](https://github.com/sourcegraph/lsif-go/pull/152)
+
 ## v1.4.0
 
 ### Added

--- a/internal/git/infer_module_version.go
+++ b/internal/git/infer_module_version.go
@@ -23,13 +23,5 @@ func InferModuleVersion(dir string) (string, error) {
 		return "", fmt.Errorf("failed to get current commit: %v\n%s", err, commit)
 	}
 
-	tag, err := command.Run(dir, "git", "describe", "--tags", "--abbrev=0", "--always")
-	if err != nil {
-		return "", fmt.Errorf("failed to describe tags: %v\n%s", err, commit)
-	}
-	if tag == commit {
-		tag = "v0.0.0"
-	}
-
-	return fmt.Sprintf("%s-%s", tag, commit[:12]), nil
+	return commit[:12], nil
 }

--- a/internal/gomod/dependencies.go
+++ b/internal/gomod/dependencies.go
@@ -98,16 +98,16 @@ func parseGoListOutput(output, rootVersion string) (map[string]Module, error) {
 	return dependencies, nil
 }
 
-// versionPattern matches the form vX.Y.Z.-yyyymmddhhmmss-abcdefabcdef
-var versionPattern = regexp.MustCompile(`^(.*)-(\d{14})-([a-f0-9]{12})$`)
+// versionPattern matches a versioning ending in a 12-digit sha, e.g., vX.Y.Z.-yyyymmddhhmmss-abcdefabcdef
+var versionPattern = regexp.MustCompile(`^.*-([a-f0-9]{12})$`)
 
-// cleanVersion removes the date segment and any `+incompatible` suffix from a module
-// version string.
+// cleanVersion normalizes a module version string.
 func cleanVersion(version string) string {
-	version = strings.TrimSuffix(version, "+incompatible")
+	version = strings.TrimSpace(strings.TrimSuffix(version, "// indirect"))
+	version = strings.TrimSpace(strings.TrimSuffix(version, "+incompatible"))
 
 	if matches := versionPattern.FindStringSubmatch(version); len(matches) > 0 {
-		return fmt.Sprintf("%s-%s", matches[1], matches[3])
+		return matches[1]
 	}
 
 	return version

--- a/internal/gomod/dependencies_test.go
+++ b/internal/gomod/dependencies_test.go
@@ -67,8 +67,8 @@ func TestParseGoListOutput(t *testing.T) {
 	expected := map[string]Module{
 		"github.com/gavv/httpexpect":                        {Name: "github.com/gavv/httpexpect", Version: "v2.0.0"},
 		"github.com/getsentry/raven-go":                     {Name: "github.com/getsentry/raven-go", Version: "v0.2.0"},
-		"github.com/gfleury/go-bitbucket-v1":                {Name: "github.com/gfleury/go-bitbucket-v1", Version: "v0.0.0-e5170e3280fb"},
-		"github.com/ghodss/yaml":                            {Name: "github.com/sourcegraph/yaml", Version: "v1.0.1-0.20200714132230-56936252f152"},
+		"github.com/gfleury/go-bitbucket-v1":                {Name: "github.com/gfleury/go-bitbucket-v1", Version: "e5170e3280fb"},
+		"github.com/ghodss/yaml":                            {Name: "github.com/sourcegraph/yaml", Version: "56936252f152"},
 		"github.com/sourcegraph/sourcegraph/enterprise/lib": {Name: "./enterprise/lib", Version: "v1.2.3"},
 	}
 	if diff := cmp.Diff(expected, modules); diff != "" {
@@ -83,7 +83,7 @@ func TestCleanVersion(t *testing.T) {
 	}{
 		{input: "v2.25.0", expected: "v2.25.0"},
 		{input: "v2.25.0+incompatible", expected: "v2.25.0"},
-		{input: "v0.0.0-20190905194746-02993c407bfb", expected: "v0.0.0-02993c407bfb"},
+		{input: "v0.0.0-20190905194746-02993c407bfb", expected: "02993c407bfb"},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
We used to normalize version strings of the form `v{last tag}-20200515-{commit}` to remove the date, as we believed the last tag to be a consistent piece of data to replicate. Unfortunately git tags are mutable, so this doesn't work any more.

We now store module versions in a more reduced but accurate state:

- Tags directly on that release (v1.2.3)
- The first 12 digits of the commit hash

This information is available from both the repository defining the module as well as all dependents.