### PR TITLE
Improve go.mod-less indexing experience

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,9 @@ All notable changes to `lsif-go` are documented in this file.
 
 ## Unreleased changes
 
-Nothing yet.
+### Changed
+
+- Improve moniker identifiers for exported identifiers in projects with no go.mod file. [#153](https://github.com/sourcegraph/lsif-go/pull/153)
 
 ## v1.4.0
 

--- a/cmd/lsif-go/index.go
+++ b/cmd/lsif-go/index.go
@@ -11,7 +11,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/enterprise/lib/codeintel/lsif/protocol/writer"
 )
 
-func writeIndex(repositoryRoot, projectRoot, moduleName, moduleVersion string, dependencies map[string]gomod.Module, outFile string) error {
+func writeIndex(repositoryRoot, repositoryRemote, projectRoot, moduleName, moduleVersion string, dependencies map[string]gomod.Module, outFile string) error {
 	start := time.Now()
 
 	out, err := os.Create(outFile)
@@ -33,6 +33,7 @@ func writeIndex(repositoryRoot, projectRoot, moduleName, moduleVersion string, d
 	// set CGO_ENABLED=0. Consider maybe doing this explicitly, always.
 	indexer := indexer.New(
 		repositoryRoot,
+		repositoryRemote,
 		projectRoot,
 		toolInfo,
 		moduleName,

--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -38,6 +38,7 @@ func mainErr() error {
 
 	return writeIndex(
 		repositoryRoot,
+		repositoryRemote,
 		projectRoot,
 		moduleName,
 		moduleVersion,

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -19,14 +19,15 @@ import (
 )
 
 type Indexer struct {
-	repositoryRoot string                  // path to repository
-	projectRoot    string                  // path to package
-	toolInfo       protocol.ToolInfo       // metadata vertex payload
-	moduleName     string                  // name of this module
-	moduleVersion  string                  // version of this module
-	dependencies   map[string]gomod.Module // parsed module data
-	emitter        *writer.Emitter         // LSIF data emitter
-	outputOptions  OutputOptions           // What to print to stdout/stderr
+	repositoryRoot   string                  // path to repository
+	repositoryRemote string                  // import path inferred by git remote
+	projectRoot      string                  // path to package
+	toolInfo         protocol.ToolInfo       // metadata vertex payload
+	moduleName       string                  // name of this module
+	moduleVersion    string                  // version of this module
+	dependencies     map[string]gomod.Module // parsed module data
+	emitter          *writer.Emitter         // LSIF data emitter
+	outputOptions    OutputOptions           // What to print to stdout/stderr
 
 	// Definition type cache
 	consts  map[interface{}]*DefinitionInfo // position -> info
@@ -62,6 +63,7 @@ type Indexer struct {
 
 func New(
 	repositoryRoot string,
+	repositoryRemote string,
 	projectRoot string,
 	toolInfo protocol.ToolInfo,
 	moduleName string,
@@ -73,6 +75,7 @@ func New(
 ) *Indexer {
 	return &Indexer{
 		repositoryRoot:        repositoryRoot,
+		repositoryRemote:      repositoryRemote,
 		projectRoot:           projectRoot,
 		toolInfo:              toolInfo,
 		moduleName:            moduleName,

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -15,6 +15,7 @@ func TestIndexer(t *testing.T) {
 	projectRoot := getRepositoryRoot(t)
 	indexer := New(
 		"/dev/github.com/sourcegraph/lsif-go/internal/testdata",
+		"github.com/sourcegraph/lsif-go",
 		projectRoot,
 		protocol.ToolInfo{Name: "lsif-go", Version: "dev"},
 		"testdata",
@@ -351,6 +352,7 @@ func TestIndexer_shouldVisitPackage(t *testing.T) {
 	projectRoot := getRepositoryRoot(t)
 	indexer := New(
 		"/dev/github.com/sourcegraph/lsif-go/internal/testdata",
+		"github.com/sourcegraph/lsif-go",
 		projectRoot,
 		protocol.ToolInfo{Name: "lsif-go", Version: "dev"},
 		"testdata",

--- a/internal/indexer/moniker.go
+++ b/internal/indexer/moniker.go
@@ -17,9 +17,14 @@ func (i *Indexer) emitExportMoniker(sourceID uint64, p *packages.Package, obj ty
 		return
 	}
 
+	packageName := monikerPackage(obj)
+	if strings.HasPrefix(packageName, "_"+i.projectRoot) {
+		packageName = i.repositoryRemote + strings.TrimSuffix(packageName[len(i.projectRoot)+1:], "_test")
+	}
+
 	// Emit export moniker (uncached as these are on unique definitions)
 	monikerID := i.emitter.EmitMoniker("export", "gomod", joinMonikerParts(
-		monikerPackage(obj),
+		packageName,
 		monikerIdentifier(i.packageDataCache, p, obj),
 	))
 


### PR DESCRIPTION
Fix name of exported package in projects without a go.mod file. With `GO111MODULE=off`, the packages being indexed have names like `_/path/to/this/project` instead of the usual import path. In the case of no go.mod file, we use a pruned name of the remote repository which we infer to be a valid import path. We use this value instead when the package begins with `_{indexing path}`.