### PR TITLE
Fix definition of nested types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ All notable changes to `lsif-go` are documented in this file.
 
 ### Fixed
 
-- Fixed definition relationship with nested structs and interfaces. [#156](https://github.com/sourcegraph/lsif-go/pull/156)
+- Fixed definition relationship with composite structs and interfaces. [#156](https://github.com/sourcegraph/lsif-go/pull/156)
 
 ## v1.4.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ All notable changes to `lsif-go` are documented in this file.
 - :rotating_light: Changed package module version generation to make cross-index queries accurate. Cross-linking may not work with indexes created before v1.5.0. [#152](https://github.com/sourcegraph/lsif-go/pull/152)
 - Improve moniker identifiers for exported identifiers in projects with no go.mod file. [#153](https://github.com/sourcegraph/lsif-go/pull/153)
 
+### Fixed
+
+- Fixed definition relationship with nested structs and interfaces. [#156](https://github.com/sourcegraph/lsif-go/pull/156)
+
 ## v1.4.0
 
 ### Added

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -432,7 +432,7 @@ func (i *Indexer) markRange(pos token.Position) bool {
 func (i *Indexer) indexDefinition(p *packages.Package, filename string, document *DocumentInfo, pos token.Position, obj types.Object, typeSwitchHeader bool, ident *ast.Ident) uint64 {
 	// Ensure the range exists, but don't emit a new one as it might already exist due to another
 	// phase of indexing (such as symbols) having emitted the range.
-	rangeID := i.ensureRangeFor(pos, obj)
+	rangeID, _ := i.ensureRangeFor(pos, obj)
 	resultSetID := i.emitter.EmitResultSet()
 	defResultID := i.emitter.EmitDefinitionResult()
 
@@ -462,11 +462,12 @@ func (i *Indexer) indexDefinition(p *packages.Package, filename string, document
 	}
 
 	i.setDefinitionInfo(obj, ident, &DefinitionInfo{
-		DocumentID:        document.DocumentID,
-		RangeID:           rangeID,
-		ResultSetID:       resultSetID,
-		ReferenceRangeIDs: map[uint64][]uint64{},
-		TypeSwitchHeader:  typeSwitchHeader,
+		DocumentID:         document.DocumentID,
+		RangeID:            rangeID,
+		ResultSetID:        resultSetID,
+		DefinitionResultID: defResultID,
+		ReferenceRangeIDs:  map[uint64][]uint64{},
+		TypeSwitchHeader:   typeSwitchHeader,
 	})
 
 	return rangeID
@@ -576,8 +577,12 @@ func (i *Indexer) getDefinitionInfo(obj types.Object, ident *ast.Ident) *Definit
 // indexReferenceToDefinition emits data for the given reference object that is defined within
 // an index target package.
 func (i *Indexer) indexReferenceToDefinition(p *packages.Package, document *DocumentInfo, pos token.Position, definitionObj types.Object, d *DefinitionInfo) (uint64, bool) {
-	rangeID := i.ensureRangeFor(pos, definitionObj)
-	_ = i.emitter.EmitNext(rangeID, d.ResultSetID)
+	rangeID, ok := i.ensureRangeFor(pos, definitionObj)
+	if !ok {
+		_ = i.emitter.EmitTextDocumentDefinition(rangeID, d.DefinitionResultID)
+	} else {
+		_ = i.emitter.EmitNext(rangeID, d.ResultSetID)
+	}
 
 	d.m.Lock()
 	d.ReferenceRangeIDs[document.DocumentID] = append(d.ReferenceRangeIDs[document.DocumentID], rangeID)
@@ -613,7 +618,7 @@ func (i *Indexer) indexReferenceToExternalDefinition(p *packages.Package, docume
 		return findExternalHoverContents(i.packageDataCache, i.packages, p, definitionObj)
 	})
 
-	rangeID := i.ensureRangeFor(pos, definitionObj)
+	rangeID, _ := i.ensureRangeFor(pos, definitionObj)
 	refResultID := i.emitter.EmitReferenceResult()
 	_ = i.emitter.EmitTextDocumentReferences(rangeID, refResultID)
 	_ = i.emitter.EmitItemOfReferences(refResultID, []uint64{rangeID}, document.DocumentID)
@@ -628,12 +633,12 @@ func (i *Indexer) indexReferenceToExternalDefinition(p *packages.Package, docume
 
 // ensureRangeFor returns a range identifier for the given object. If a range for the object has
 // not been emitted, a new vertex is created.
-func (i *Indexer) ensureRangeFor(pos token.Position, obj types.Object) uint64 {
+func (i *Indexer) ensureRangeFor(pos token.Position, obj types.Object) (uint64, bool) {
 	i.stripedMutex.RLockKey(pos.Filename)
 	rangeID, ok := i.ranges[pos.Filename][pos.Offset]
 	i.stripedMutex.RUnlockKey(pos.Filename)
 	if ok {
-		return rangeID
+		return rangeID, false
 	}
 
 	// Note: we calculate this outside of the critical section
@@ -643,12 +648,12 @@ func (i *Indexer) ensureRangeFor(pos token.Position, obj types.Object) uint64 {
 	defer i.stripedMutex.UnlockKey(pos.Filename)
 
 	if rangeID, ok := i.ranges[pos.Filename][pos.Offset]; ok {
-		return rangeID
+		return rangeID, false
 	}
 
 	rangeID = i.emitter.EmitRange(start, end)
 	i.ranges[pos.Filename][pos.Offset] = rangeID
-	return rangeID
+	return rangeID, true
 }
 
 // linkReferenceResultsToRanges emits item relations for each indexed definition result value.

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -338,6 +338,21 @@ func TestIndexer(t *testing.T) {
 			t.Fatalf("found range for anonymous struct when not expected")
 		}
 	})
+
+	t.Run("check nested struct definition", func(t *testing.T) {
+		r, ok := findRange(w.elements, "file://"+filepath.Join(projectRoot, "composite.go"), 11, 1)
+		if !ok {
+			t.Fatalf("could not find target range")
+		}
+
+		definitions := findDefinitionRangesByRangeOrResultSetID(w.elements, r.ID)
+		if len(definitions) != 2 {
+			t.Fatalf("incorrect definition count. want=%d have=%d", 2, len(definitions))
+		}
+
+		compareRange(t, definitions[0], 4, 5, 4, 10)
+		compareRange(t, definitions[1], 11, 1, 11, 6)
+	})
 }
 
 func TestIndexer_documentation(t *testing.T) {

--- a/internal/indexer/info.go
+++ b/internal/indexer/info.go
@@ -28,10 +28,11 @@ type DocumentInfo struct {
 // of this shape is keyed by type and identifier in the indexer so that it can be
 // re-retrieved for a range that uses the definition.
 type DefinitionInfo struct {
-	DocumentID        uint64
-	RangeID           uint64
-	ResultSetID       uint64
-	ReferenceRangeIDs map[uint64][]uint64
-	TypeSwitchHeader  bool
-	m                 sync.Mutex
+	DocumentID         uint64
+	RangeID            uint64
+	ResultSetID        uint64
+	DefinitionResultID uint64
+	ReferenceRangeIDs  map[uint64][]uint64
+	TypeSwitchHeader   bool
+	m                  sync.Mutex
 }

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata.golden
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata.golden
@@ -43,6 +43,8 @@ testdata is a small package containing sample Go source code used for testing th
     - [func NewInterface() Interface](#github.com-sourcegraph-lsif-go-internal-testdata-type-Interface-NewInterface)
   - [type X struct](#github.com-sourcegraph-lsif-go-internal-testdata-type-X)
   - [type Y struct](#github.com-sourcegraph-lsif-go-internal-testdata-type-Y)
+  - [type Inner struct](#github.com-sourcegraph-lsif-go-internal-testdata-type-Inner)
+  - [type Outer struct](#github.com-sourcegraph-lsif-go-internal-testdata-type-Outer)
   - [type TestInterface interface](#github.com-sourcegraph-lsif-go-internal-testdata-type-TestInterface)
   - [type TestStruct struct](#github.com-sourcegraph-lsif-go-internal-testdata-type-TestStruct)
     - [func (ts *TestStruct) Doer(ctx context.Context, data string) (score int, err error)](#github.com-sourcegraph-lsif-go-internal-testdata-type-TestStruct-Doer)
@@ -54,6 +56,7 @@ testdata is a small package containing sample Go source code used for testing th
   - [type SecretBurger secret.Burger](#github.com-sourcegraph-lsif-go-internal-testdata-type-SecretBurger)
   - [type BadBurger struct](#github.com-sourcegraph-lsif-go-internal-testdata-type-BadBurger)
 - [Functions](#github.com-sourcegraph-lsif-go-internal-testdata-func)
+  - [func useOfCompositeStructs()](#github.com-sourcegraph-lsif-go-internal-testdata-func-useOfCompositeStructs)
   - [func Parallel(ctx context.Context, fns ...ParallelizableFunc) error](#github.com-sourcegraph-lsif-go-internal-testdata-func-Parallel)
   - [func Switch(interfaceValue interface{}) bool](#github.com-sourcegraph-lsif-go-internal-testdata-func-Switch)
 
@@ -286,6 +289,25 @@ type Y struct {
 
 Go can be fun 
 
+#### <a name="github.com-sourcegraph-lsif-go-internal-testdata-type-Inner">type Inner struct <small>(exported)</small></a>
+
+```Go
+type Inner struct {
+	X int
+	Y int
+	Z int
+}
+```
+
+#### <a name="github.com-sourcegraph-lsif-go-internal-testdata-type-Outer">type Outer struct <small>(exported)</small></a>
+
+```Go
+type Outer struct {
+	Inner
+	W int
+}
+```
+
 #### <a name="github.com-sourcegraph-lsif-go-internal-testdata-type-TestInterface">type TestInterface interface <small>(exported)</small></a>
 
 ```Go
@@ -387,6 +409,12 @@ type BadBurger = struct {
 ```
 
 ### <a name="github.com-sourcegraph-lsif-go-internal-testdata-func">Functions</a>
+
+#### <a name="github.com-sourcegraph-lsif-go-internal-testdata-func-useOfCompositeStructs">func useOfCompositeStructs()</a>
+
+```Go
+func useOfCompositeStructs()
+```
 
 #### <a name="github.com-sourcegraph-lsif-go-internal-testdata-func-Parallel">func Parallel(ctx context.Context, fns ...ParallelizableFunc) error <small>(exported)</small></a>
 

--- a/internal/testdata/composite.go
+++ b/internal/testdata/composite.go
@@ -1,0 +1,12 @@
+package testdata
+
+type Inner struct {
+	X int
+	Y int
+	Z int
+}
+
+type Outer struct {
+	Inner
+	W int
+}

--- a/internal/testdata/composite.go
+++ b/internal/testdata/composite.go
@@ -1,5 +1,7 @@
 package testdata
 
+import "fmt"
+
 type Inner struct {
 	X int
 	Y int
@@ -9,4 +11,17 @@ type Inner struct {
 type Outer struct {
 	Inner
 	W int
+}
+
+func useOfCompositeStructs() {
+	o := Outer{
+		Inner: Inner{
+			X: 1,
+			Y: 2,
+			Z: 3,
+		},
+		W: 4,
+	}
+
+	fmt.Printf("> %d\n", o.X)
 }


### PR DESCRIPTION
For nested structs and interfaces, we were attaching two result sets to the same range, which is invalid. We now instead find the cases where this happens (nested type fields that act as a field and a type in the same token) and emitted the correct relationships.

We now link the field range directly to the definition result of the type.  This emits two definition results in the correct order (so that g2d will find the first one) for such fields:

- the struct definition (direct)
- the field definition (via result set, self, old definition)