### PR TITLE
Fall back to empty suffix when given module is not resolvable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ All notable changes to `lsif-go` are documented in this file.
 
 - Fixed moniker identifiers for composite structs and interfaces. [#135](https://github.com/sourcegraph/lsif-go/pull/135)
 - Fixed definition relationship with composite structs and interfaces. [#156](https://github.com/sourcegraph/lsif-go/pull/156)
+- Fixed error-on-startup caused by unresolvable module name in go.mod file. [#157](https://github.com/sourcegraph/lsif-go/pull/157)
 
 ## v1.4.0
 

--- a/internal/git/infer_repo_test.go
+++ b/internal/git/infer_repo_test.go
@@ -18,8 +18,9 @@ func TestInferRepo(t *testing.T) {
 
 func TestParseRemote(t *testing.T) {
 	testCases := map[string]string{
-		"git@github.com:sourcegraph/lsif-go.git": "github.com/sourcegraph/lsif-go",
-		"https://github.com/sourcegraph/lsif-go": "github.com/sourcegraph/lsif-go",
+		"git@github.com:sourcegraph/lsif-go.git":                                "github.com/sourcegraph/lsif-go",
+		"https://github.com/sourcegraph/lsif-go":                                "github.com/sourcegraph/lsif-go",
+		"ssh://git@phabricator.company.com:2222/diffusion/COMPANY/companay.git": "phabricator.company.com/diffusion/COMPANY/companay",
 	}
 
 	for input, expectedOutput := range testCases {

--- a/internal/gomod/module_name.go
+++ b/internal/gomod/module_name.go
@@ -33,11 +33,14 @@ func ModuleName(dir, repo string) (string, error) {
 // is used only to determine the path suffix.
 func resolveModuleName(repo, name string) (string, error) {
 	// Determine path suffix relative to repository root
-	nameRepoRoot, err := vcs.RepoRootForImportPath(name, false)
-	if err != nil {
-		return "", err
+	var suffix string
+
+	if nameRepoRoot, err := vcs.RepoRootForImportPath(name, false); err == nil {
+		suffix = strings.TrimPrefix(name, nameRepoRoot.Root)
+	} else {
+		// A user-visible warning will occur on this path as the declared
+		// module will be resolved as part of gomod.ListDependencies.
 	}
-	suffix := strings.TrimPrefix(name, nameRepoRoot.Root)
 
 	// Determine the canonical code host of the current repository
 	repoRepoRoot, err := vcs.RepoRootForImportPath(repo, false)


### PR DESCRIPTION
Go module files containing a declaration of a module like `mycompany.com` currently fails to resolve. We just fall back to an empty suffix in this case. This case will still display a warning to the user when it tries to resolve it as part of the dependency resolution. The user can change this behavior by supplying an explicit module name via flag, or fall back to using the repository remote.