### PR TITLE
 awkward: some of our testdata Go files have syntax errors!

### DIFF
--- a/buildkite.yml
+++ b/buildkite.yml
@@ -1,3 +1,5 @@
 steps:
   - label: ':go:'
+    command: find internal/testdata -type f -name '*.go' -exec go fmt {} \;
+  - label: ':go:'
     command: go test ./...

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata.golden
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata.golden
@@ -38,6 +38,9 @@ testdata is a small package containing sample Go source code used for testing th
 - [Types](#github.com-sourcegraph-lsif-go-internal-testdata---type)
   - [type Embedded struct](#github.com-sourcegraph-lsif-go-internal-testdata---Embedded)
   - [type Struct struct](#github.com-sourcegraph-lsif-go-internal-testdata---Struct)
+    - [func (s *Struct) StructMethod()](#github.com-sourcegraph-lsif-go-internal-testdata---Struct.StructMethod)
+    - [func (s *Struct) ImplementsInterface() string](#github.com-sourcegraph-lsif-go-internal-testdata---Struct.ImplementsInterface)
+    - [func (s *Struct) MachineLearning(param1 float32,...](#github.com-sourcegraph-lsif-go-internal-testdata---Struct.MachineLearning)
   - [type Interface interface](#github.com-sourcegraph-lsif-go-internal-testdata---Interface)
     - [func NewInterface() Interface](#github.com-sourcegraph-lsif-go-internal-testdata---NewInterface)
   - [type X struct](#github.com-sourcegraph-lsif-go-internal-testdata---X)
@@ -1311,6 +1314,203 @@ type Struct struct {
 		FieldC int
 	}
 }
+```
+
+##### <a name="github.com-sourcegraph-lsif-go-internal-testdata---Struct.StructMethod">func (s *Struct) StructMethod() <small>(exported)</small></a>
+
+<details><summary>hover</summary>
+
+> ```go
+> func (*Struct).StructMethod()
+> ```
+> 
+> ---
+> 
+> StructMethod has some docs!
+
+</details>
+
+<details><summary>definitions</summary>
+
+```json
+[
+ {
+  "Document": "/child_symbols.go",
+  "Ranges": [
+   {
+    "start": {
+     "line": 69,
+     "character": 17
+    },
+    "end": {
+     "line": 69,
+     "character": 29
+    }
+   }
+  ]
+ }
+]
+```
+
+</details>
+
+<details><summary>references</summary>
+
+```json
+[
+ {
+  "Document": "/child_symbols.go",
+  "Ranges": [
+   {
+    "start": {
+     "line": 69,
+     "character": 17
+    },
+    "end": {
+     "line": 69,
+     "character": 29
+    }
+   }
+  ]
+ }
+]
+```
+
+</details>
+
+```Go
+func (s *Struct) StructMethod()
+```
+
+StructMethod has some docs! 
+
+##### <a name="github.com-sourcegraph-lsif-go-internal-testdata---Struct.ImplementsInterface">func (s *Struct) ImplementsInterface() string <small>(exported)</small></a>
+
+<details><summary>hover</summary>
+
+> ```go
+> func (*Struct).ImplementsInterface() string
+> ```
+
+</details>
+
+<details><summary>definitions</summary>
+
+```json
+[
+ {
+  "Document": "/child_symbols.go",
+  "Ranges": [
+   {
+    "start": {
+     "line": 71,
+     "character": 17
+    },
+    "end": {
+     "line": 71,
+     "character": 36
+    }
+   }
+  ]
+ }
+]
+```
+
+</details>
+
+<details><summary>references</summary>
+
+```json
+[
+ {
+  "Document": "/child_symbols.go",
+  "Ranges": [
+   {
+    "start": {
+     "line": 71,
+     "character": 17
+    },
+    "end": {
+     "line": 71,
+     "character": 36
+    }
+   }
+  ]
+ }
+]
+```
+
+</details>
+
+```Go
+func (s *Struct) ImplementsInterface() string
+```
+
+##### <a name="github.com-sourcegraph-lsif-go-internal-testdata---Struct.MachineLearning">func (s *Struct) MachineLearning(param1 float32,... <small>(exported)</small></a>
+
+<details><summary>hover</summary>
+
+> ```go
+> func (*Struct).MachineLearning(param1 float32, hyperparam2 float32, hyperparam3 float32) float32
+> ```
+
+</details>
+
+<details><summary>definitions</summary>
+
+```json
+[
+ {
+  "Document": "/child_symbols.go",
+  "Ranges": [
+   {
+    "start": {
+     "line": 73,
+     "character": 17
+    },
+    "end": {
+     "line": 73,
+     "character": 32
+    }
+   }
+  ]
+ }
+]
+```
+
+</details>
+
+<details><summary>references</summary>
+
+```json
+[
+ {
+  "Document": "/child_symbols.go",
+  "Ranges": [
+   {
+    "start": {
+     "line": 73,
+     "character": 17
+    },
+    "end": {
+     "line": 73,
+     "character": 32
+    }
+   }
+  ]
+ }
+]
+```
+
+</details>
+
+```Go
+func (s *Struct) MachineLearning(
+	param1 float32,
+
+	hyperparam2 float32,
+	hyperparam3 float32,
+) float32
 ```
 
 #### <a name="github.com-sourcegraph-lsif-go-internal-testdata---Interface">type Interface interface <small>(exported)</small></a>

--- a/internal/testdata/child_symbols.go
+++ b/internal/testdata/child_symbols.go
@@ -42,7 +42,7 @@ var BigVar Interface = &Struct{
 //
 // It's sleeping! Some people write that as `sleeping` but Markdown
 // isn't allowed in Go docstrings, right? right?!
-var(
+var (
 	// This has some docs
 	VarBlock1 = "if you're reading this"
 
@@ -53,18 +53,18 @@ var(
 type Embedded struct {
 	// EmbeddedField has some docs!
 	EmbeddedField string
-	Field string // conflicts with parent "Field"
+	Field         string // conflicts with parent "Field"
 }
 
 type Struct struct {
 	*Embedded
-	Field string
+	Field     string
 	Anonymous struct {
 		FieldA int
 		FieldB int
 		FieldC int
 	}
-}}
+}
 
 // StructMethod has some docs!
 func (s *Struct) StructMethod() {}
@@ -89,9 +89,9 @@ func (s *Struct) MachineLearning(
 	// 	   `--'   `--'
 	//
 	hyperparam2 float32,
-	hyperparam3 float32
+	hyperparam3 float32,
 ) float32 {
-	return param1+(hyperparam2**hyperparam3) // lol is this all ML is? I'm gonna be rich
+	return param1 + (hyperparam2 * *hyperparam3) // lol is this all ML is? I'm gonna be rich
 }
 
 // Interface has docs too


### PR DESCRIPTION
```
$ find internal/testdata -type f -name '*.go' -exec go fmt {} \;
internal/testdata/child_symbols.go:67:2: expected declaration, found '}'
exit status 2
```

I didn't realize this because the Go parser is surprisingly good (and silent)
about handling file parsing errors, and `go fmt ./...` ignores `testdata/` files.

This adds a CI check which ensures our files are syntactically valid at least.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>