### PR TITLE
API docs: emit many more tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/mattn/go-isatty v0.0.13 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3
-	github.com/sourcegraph/lsif-static-doc v0.0.0-20210622190916-b0f2e78b9eb4
+	github.com/sourcegraph/lsif-static-doc v0.0.0-20210623221800-07cfeb32c554
 	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210623200400-a0c9333770a7
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	golang.org/x/tools v0.1.3

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3
 	github.com/sourcegraph/lsif-static-doc v0.0.0-20210622190916-b0f2e78b9eb4
-	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622231052-467e52d22f61
+	github.com/sourcegraph/sourcegraph/lib v0.0.0-20210623200400-a0c9333770a7
 	golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 // indirect
 	golang.org/x/tools v0.1.3
 	mvdan.cc/gofumpt v0.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -230,8 +230,8 @@ github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm
 github.com/sourcegraph/lsif-static-doc v0.0.0-20210622190916-b0f2e78b9eb4 h1:p73W94RhEK9npeR2C7g9eKCXpKOQm/6NO9w0bcdBx50=
 github.com/sourcegraph/lsif-static-doc v0.0.0-20210622190916-b0f2e78b9eb4/go.mod h1:47Sfj+qivcqfyQhbpeWpV2LpR1Z51YIBU4LNt7UxPrw=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622190720-de278ea3dd5c/go.mod h1:0Df1LLzPHhuxInVdcV/eIR7BVl1+R0rch5fSIK8+w5Y=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622231052-467e52d22f61 h1:VkI9MfnGd9KcDz0Xw8bgypa3dLVVu6ysMgfN3Tpon8Q=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622231052-467e52d22f61/go.mod h1:0Df1LLzPHhuxInVdcV/eIR7BVl1+R0rch5fSIK8+w5Y=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210623200400-a0c9333770a7 h1:oMt6yAUEg659qDCtySdPeJ6tR4+fD/ocn8qzdmAce/8=
+github.com/sourcegraph/sourcegraph/lib v0.0.0-20210623200400-a0c9333770a7/go.mod h1:0Df1LLzPHhuxInVdcV/eIR7BVl1+R0rch5fSIK8+w5Y=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=

--- a/go.sum
+++ b/go.sum
@@ -227,9 +227,8 @@ github.com/slimsag/godocmd v0.0.0-20161025000126-a1005ad29fe3/go.mod h1:AIBPxLCk
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
 github.com/sourcegraph/jsonx v0.0.0-20200629203448-1a936bd500cf/go.mod h1:ppFaPm6kpcHnZGqQTFhUIAQRIEhdQDWP1PCv4/ON354=
-github.com/sourcegraph/lsif-static-doc v0.0.0-20210622190916-b0f2e78b9eb4 h1:p73W94RhEK9npeR2C7g9eKCXpKOQm/6NO9w0bcdBx50=
-github.com/sourcegraph/lsif-static-doc v0.0.0-20210622190916-b0f2e78b9eb4/go.mod h1:47Sfj+qivcqfyQhbpeWpV2LpR1Z51YIBU4LNt7UxPrw=
-github.com/sourcegraph/sourcegraph/lib v0.0.0-20210622190720-de278ea3dd5c/go.mod h1:0Df1LLzPHhuxInVdcV/eIR7BVl1+R0rch5fSIK8+w5Y=
+github.com/sourcegraph/lsif-static-doc v0.0.0-20210623221800-07cfeb32c554 h1:un0UKTlQHAUO0ZN4lvjITJVQafplXf7Tjai2lhJpD5g=
+github.com/sourcegraph/lsif-static-doc v0.0.0-20210623221800-07cfeb32c554/go.mod h1:4jbq7frBUBBm/Ipjb6ffDUZGvlNdJd1VeVShrgP8ewo=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20210623200400-a0c9333770a7 h1:oMt6yAUEg659qDCtySdPeJ6tR4+fD/ocn8qzdmAce/8=
 github.com/sourcegraph/sourcegraph/lib v0.0.0-20210623200400-a0c9333770a7/go.mod h1:0Df1LLzPHhuxInVdcV/eIR7BVl1+R0rch5fSIK8+w5Y=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=

--- a/internal/indexer/documentation.go
+++ b/internal/indexer/documentation.go
@@ -291,12 +291,12 @@ func (d *docsIndexer) indexPackage(p *packages.Package) (docsPackage, error) {
 	rootPkgPath := d.rootPkgPath()
 	shortestUniquePkgPath := strings.TrimPrefix(strings.TrimPrefix(pkgPathStdStrip(p.PkgPath), rootPkgPath), "/")
 
-	pkgTags := []protocol.DocumentationTag{}
+	pkgTags := []protocol.Tag{}
 	if strings.Contains(p.PkgPath, "/internal/") || strings.HasSuffix(p.Name, "_test") {
-		pkgTags = append(pkgTags, protocol.DocumentationPrivate)
+		pkgTags = append(pkgTags, protocol.TagPrivate)
 	}
 	if isDeprecated(pkgDocsMarkdown) {
-		pkgTags = append(pkgTags, protocol.DocumentationDeprecated)
+		pkgTags = append(pkgTags, protocol.TagDeprecated)
 	}
 	pkgPathElements := strings.Split(pkgPathStdStrip(p.PkgPath), "/")
 	packageDocsID := (&documentationResult{
@@ -563,12 +563,12 @@ type constVarDocs struct {
 }
 
 func (t constVarDocs) result() *documentationResult {
-	var tags []protocol.DocumentationTag
+	var tags []protocol.Tag
 	if !t.exported {
-		tags = append(tags, protocol.DocumentationPrivate)
+		tags = append(tags, protocol.TagPrivate)
 	}
 	if t.deprecated {
-		tags = append(tags, protocol.DocumentationDeprecated)
+		tags = append(tags, protocol.TagDeprecated)
 	}
 
 	// Include the full type signature
@@ -649,12 +649,12 @@ type typeDocs struct {
 }
 
 func (t typeDocs) result() *documentationResult {
-	var tags []protocol.DocumentationTag
+	var tags []protocol.Tag
 	if !t.exported {
-		tags = append(tags, protocol.DocumentationPrivate)
+		tags = append(tags, protocol.TagPrivate)
 	}
 	if t.deprecated {
-		tags = append(tags, protocol.DocumentationDeprecated)
+		tags = append(tags, protocol.TagDeprecated)
 	}
 
 	// Include the full type signature
@@ -733,12 +733,12 @@ type funcDocs struct {
 }
 
 func (f funcDocs) result() *documentationResult {
-	var tags []protocol.DocumentationTag
+	var tags []protocol.Tag
 	if !f.exported {
-		tags = append(tags, protocol.DocumentationPrivate)
+		tags = append(tags, protocol.TagPrivate)
 	}
 	if f.deprecated {
-		tags = append(tags, protocol.DocumentationDeprecated)
+		tags = append(tags, protocol.TagDeprecated)
 	}
 
 	// Include the full type signature

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.json
@@ -5,6 +5,7 @@
     "newPage": true,
     "searchKey": "duplicate_path_id",
     "tags": [
+      "package",
       "private"
     ]
   },
@@ -25,6 +26,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -45,6 +47,7 @@
                 "newPage": false,
                 "searchKey": "gosrc.importMeta",
                 "tags": [
+                  "struct",
                   "private"
                 ]
               },
@@ -65,6 +68,7 @@
                       "newPage": false,
                       "searchKey": "gosrc.fetchMeta",
                       "tags": [
+                        "function",
                         "private"
                       ]
                     },
@@ -90,6 +94,7 @@
                 "newPage": false,
                 "searchKey": "gosrc.sourceMeta",
                 "tags": [
+                  "struct",
                   "private"
                 ]
               },
@@ -115,6 +120,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -135,6 +141,7 @@
                 "newPage": false,
                 "searchKey": "gosrc.init",
                 "tags": [
+                  "function",
                   "private"
                 ]
               },
@@ -157,6 +164,7 @@
                 "newPage": false,
                 "searchKey": "gosrc.init",
                 "tags": [
+                  "function",
                   "private"
                 ]
               },

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.md
@@ -14,14 +14,14 @@
 ## <a id="type" href="#type">Types</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="importMeta" href="#importMeta">type importMeta struct{}</a>
 
 ```
 searchKey: gosrc.importMeta
-tags: [private]
+tags: [struct private]
 ```
 
 ```Go
@@ -32,7 +32,7 @@ type importMeta struct{}
 
 ```
 searchKey: gosrc.fetchMeta
-tags: [private]
+tags: [function private]
 ```
 
 ```Go
@@ -43,7 +43,7 @@ func fetchMeta() (string, *importMeta, *sourceMeta)
 
 ```
 searchKey: gosrc.sourceMeta
-tags: [private]
+tags: [struct private]
 ```
 
 ```Go
@@ -53,14 +53,14 @@ type sourceMeta struct{}
 ## <a id="func" href="#func">Functions</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="init.main.go" href="#init.main.go">func init()</a>
 
 ```
 searchKey: gosrc.init
-tags: [private]
+tags: [function private]
 ```
 
 ```Go
@@ -71,7 +71,7 @@ func init()
 
 ```
 searchKey: gosrc.init
-tags: [private]
+tags: [function private]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
@@ -5,6 +5,7 @@
     "newPage": true,
     "searchKey": "",
     "tags": [
+      "package",
       "private"
     ]
   },
@@ -28,6 +29,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -47,7 +49,10 @@
                 "identifier": "Const",
                 "newPage": false,
                 "searchKey": "testdata.Const",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "number"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -67,7 +72,10 @@
                 "identifier": "ConstBlock1",
                 "newPage": false,
                 "searchKey": "testdata.ConstBlock1",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "number"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -87,7 +95,10 @@
                 "identifier": "ConstBlock2",
                 "newPage": false,
                 "searchKey": "testdata.ConstBlock2",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "number"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -107,7 +118,10 @@
                 "identifier": "Score",
                 "newPage": false,
                 "searchKey": "testdata.Score",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "number"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -128,6 +142,8 @@
                 "newPage": false,
                 "searchKey": "testdata.secretScore",
                 "tags": [
+                  "constant",
+                  "number",
                   "private"
                 ]
               },
@@ -149,7 +165,10 @@
                 "identifier": "SomeString",
                 "newPage": false,
                 "searchKey": "testdata.SomeString",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "string"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -169,7 +188,10 @@
                 "identifier": "LongString",
                 "newPage": false,
                 "searchKey": "testdata.LongString",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "string"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -189,7 +211,10 @@
                 "identifier": "ConstMath",
                 "newPage": false,
                 "searchKey": "testdata.ConstMath",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "number"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -209,7 +234,10 @@
                 "identifier": "AliasedString",
                 "newPage": false,
                 "searchKey": "testdata.AliasedString",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "string"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -233,6 +261,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -252,7 +281,10 @@
                 "identifier": "Var",
                 "newPage": false,
                 "searchKey": "testdata.Var",
-                "tags": null
+                "tags": [
+                  "variable",
+                  "interface"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -273,6 +305,8 @@
                 "newPage": false,
                 "searchKey": "testdata.unexportedVar",
                 "tags": [
+                  "variable",
+                  "interface",
                   "private"
                 ]
               },
@@ -295,6 +329,8 @@
                 "newPage": false,
                 "searchKey": "testdata.x",
                 "tags": [
+                  "variable",
+                  "interface",
                   "private"
                 ]
               },
@@ -316,7 +352,10 @@
                 "identifier": "BigVar",
                 "newPage": false,
                 "searchKey": "testdata.BigVar",
-                "tags": null
+                "tags": [
+                  "variable",
+                  "interface"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -336,7 +375,10 @@
                 "identifier": "VarBlock1",
                 "newPage": false,
                 "searchKey": "testdata.VarBlock1",
-                "tags": null
+                "tags": [
+                  "variable",
+                  "string"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -356,7 +398,10 @@
                 "identifier": "VarBlock2",
                 "newPage": false,
                 "searchKey": "testdata.VarBlock2",
-                "tags": null
+                "tags": [
+                  "variable",
+                  "string"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -380,6 +425,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -399,7 +445,9 @@
                 "identifier": "Embedded",
                 "newPage": false,
                 "searchKey": "testdata.Embedded",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -419,7 +467,9 @@
                 "identifier": "Struct",
                 "newPage": false,
                 "searchKey": "testdata.Struct",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -437,7 +487,9 @@
                       "identifier": "Struct.StructMethod",
                       "newPage": false,
                       "searchKey": "testdata.Struct.StructMethod",
-                      "tags": null
+                      "tags": [
+                        "function"
+                      ]
                     },
                     "label": {
                       "kind": "plaintext",
@@ -457,7 +509,9 @@
                       "identifier": "Struct.ImplementsInterface",
                       "newPage": false,
                       "searchKey": "testdata.Struct.ImplementsInterface",
-                      "tags": null
+                      "tags": [
+                        "function"
+                      ]
                     },
                     "label": {
                       "kind": "plaintext",
@@ -477,7 +531,9 @@
                       "identifier": "Struct.MachineLearning",
                       "newPage": false,
                       "searchKey": "testdata.Struct.MachineLearning",
-                      "tags": null
+                      "tags": [
+                        "method"
+                      ]
                     },
                     "label": {
                       "kind": "plaintext",
@@ -500,7 +556,9 @@
                 "identifier": "Interface",
                 "newPage": false,
                 "searchKey": "testdata.Interface",
-                "tags": null
+                "tags": [
+                  "interface"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -518,7 +576,9 @@
                       "identifier": "NewInterface",
                       "newPage": false,
                       "searchKey": "testdata.NewInterface",
-                      "tags": null
+                      "tags": [
+                        "function"
+                      ]
                     },
                     "label": {
                       "kind": "plaintext",
@@ -541,7 +601,9 @@
                 "identifier": "X",
                 "newPage": false,
                 "searchKey": "testdata.X",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -561,7 +623,9 @@
                 "identifier": "Y",
                 "newPage": false,
                 "searchKey": "testdata.Y",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -581,7 +645,9 @@
                 "identifier": "Inner",
                 "newPage": false,
                 "searchKey": "testdata.Inner",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -601,7 +667,9 @@
                 "identifier": "Outer",
                 "newPage": false,
                 "searchKey": "testdata.Outer",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -621,7 +689,9 @@
                 "identifier": "TestInterface",
                 "newPage": false,
                 "searchKey": "testdata.TestInterface",
-                "tags": null
+                "tags": [
+                  "interface"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -641,7 +711,9 @@
                 "identifier": "TestStruct",
                 "newPage": false,
                 "searchKey": "testdata.TestStruct",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -659,7 +731,9 @@
                       "identifier": "TestStruct.Doer",
                       "newPage": false,
                       "searchKey": "testdata.TestStruct.Doer",
-                      "tags": null
+                      "tags": [
+                        "method"
+                      ]
                     },
                     "label": {
                       "kind": "plaintext",
@@ -682,7 +756,9 @@
                 "identifier": "TestEmptyStruct",
                 "newPage": false,
                 "searchKey": "testdata.TestEmptyStruct",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -702,7 +778,9 @@
                 "identifier": "StringAlias",
                 "newPage": false,
                 "searchKey": "testdata.StringAlias",
-                "tags": null
+                "tags": [
+                  "string"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -722,7 +800,9 @@
                 "identifier": "StructTagRegression",
                 "newPage": false,
                 "searchKey": "testdata.StructTagRegression",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -742,7 +822,9 @@
                 "identifier": "TestEqualsStruct",
                 "newPage": false,
                 "searchKey": "testdata.TestEqualsStruct",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -762,7 +844,9 @@
                 "identifier": "ShellStruct",
                 "newPage": false,
                 "searchKey": "testdata.ShellStruct",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -782,7 +866,9 @@
                 "identifier": "InnerStruct",
                 "newPage": false,
                 "searchKey": "testdata.InnerStruct",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -802,7 +888,9 @@
                 "identifier": "ParallelizableFunc",
                 "newPage": false,
                 "searchKey": "testdata.ParallelizableFunc",
-                "tags": null
+                "tags": [
+                  "function"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -822,7 +910,9 @@
                 "identifier": "SecretBurger",
                 "newPage": false,
                 "searchKey": "testdata.SecretBurger",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -842,7 +932,9 @@
                 "identifier": "BadBurger",
                 "newPage": false,
                 "searchKey": "testdata.BadBurger",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -866,6 +958,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -886,6 +979,7 @@
                 "newPage": false,
                 "searchKey": "testdata.useOfCompositeStructs",
                 "tags": [
+                  "function",
                   "private"
                 ]
               },
@@ -907,7 +1001,9 @@
                 "identifier": "Parallel",
                 "newPage": false,
                 "searchKey": "testdata.Parallel",
-                "tags": null
+                "tags": [
+                  "method"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -927,7 +1023,9 @@
                 "identifier": "Switch",
                 "newPage": false,
                 "searchKey": "testdata.Switch",
-                "tags": null
+                "tags": [
+                  "method"
+                ]
               },
               "label": {
                 "kind": "plaintext",

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
@@ -59,13 +59,14 @@ testdata is a small package containing sample Go source code used for testing th
 ## <a id="const" href="#const">Constants</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="Const" href="#Const">const Const</a>
 
 ```
 searchKey: testdata.Const
+tags: [constant number]
 ```
 
 ```Go
@@ -78,6 +79,7 @@ Const is a constant equal to 5. It's the best constant I've ever written. 😹
 
 ```
 searchKey: testdata.ConstBlock1
+tags: [constant number]
 ```
 
 ```Go
@@ -92,6 +94,7 @@ ConstBlock1 is a constant in a block.
 
 ```
 searchKey: testdata.ConstBlock2
+tags: [constant number]
 ```
 
 ```Go
@@ -106,6 +109,7 @@ ConstBlock2 is a constant in a block.
 
 ```
 searchKey: testdata.Score
+tags: [constant number]
 ```
 
 ```Go
@@ -118,7 +122,7 @@ Score is just a hardcoded number.
 
 ```
 searchKey: testdata.secretScore
-tags: [private]
+tags: [constant number private]
 ```
 
 ```Go
@@ -129,6 +133,7 @@ const secretScore = secret.SecretScore
 
 ```
 searchKey: testdata.SomeString
+tags: [constant string]
 ```
 
 ```Go
@@ -139,6 +144,7 @@ const SomeString = "foobar"
 
 ```
 searchKey: testdata.LongString
+tags: [constant string]
 ```
 
 ```Go
@@ -149,6 +155,7 @@ const LongString = ...
 
 ```
 searchKey: testdata.ConstMath
+tags: [constant number]
 ```
 
 ```Go
@@ -159,6 +166,7 @@ const ConstMath = 1 + (2+3)*5
 
 ```
 searchKey: testdata.AliasedString
+tags: [constant string]
 ```
 
 ```Go
@@ -168,13 +176,14 @@ const AliasedString StringAlias = "foobar"
 ## <a id="var" href="#var">Variables</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="Var" href="#Var">var Var</a>
 
 ```
 searchKey: testdata.Var
+tags: [variable interface]
 ```
 
 ```Go
@@ -187,7 +196,7 @@ Var is a variable interface.
 
 ```
 searchKey: testdata.unexportedVar
-tags: [private]
+tags: [variable interface private]
 ```
 
 ```Go
@@ -200,7 +209,7 @@ unexportedVar is an unexported variable interface.
 
 ```
 searchKey: testdata.x
-tags: [private]
+tags: [variable interface private]
 ```
 
 ```Go
@@ -213,6 +222,7 @@ x has a builtin error type
 
 ```
 searchKey: testdata.BigVar
+tags: [variable interface]
 ```
 
 ```Go
@@ -223,6 +233,7 @@ var BigVar Interface = ...
 
 ```
 searchKey: testdata.VarBlock1
+tags: [variable string]
 ```
 
 ```Go
@@ -246,6 +257,7 @@ This has some docs
 
 ```
 searchKey: testdata.VarBlock2
+tags: [variable string]
 ```
 
 ```Go
@@ -266,13 +278,14 @@ It's sleeping! Some people write that as `sleeping` but Markdown isn't allowed i
 ## <a id="type" href="#type">Types</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="Embedded" href="#Embedded">type Embedded struct</a>
 
 ```
 searchKey: testdata.Embedded
+tags: [struct]
 ```
 
 ```Go
@@ -289,6 +302,7 @@ Embedded is a struct, to be embedded in another struct.
 
 ```
 searchKey: testdata.Struct
+tags: [struct]
 ```
 
 ```Go
@@ -307,6 +321,7 @@ type Struct struct {
 
 ```
 searchKey: testdata.Struct.StructMethod
+tags: [function]
 ```
 
 ```Go
@@ -319,6 +334,7 @@ StructMethod has some docs!
 
 ```
 searchKey: testdata.Struct.ImplementsInterface
+tags: [function]
 ```
 
 ```Go
@@ -329,6 +345,7 @@ func (s *Struct) ImplementsInterface() string
 
 ```
 searchKey: testdata.Struct.MachineLearning
+tags: [method]
 ```
 
 ```Go
@@ -344,6 +361,7 @@ func (s *Struct) MachineLearning(
 
 ```
 searchKey: testdata.Interface
+tags: [interface]
 ```
 
 ```Go
@@ -358,6 +376,7 @@ Interface has docs too
 
 ```
 searchKey: testdata.NewInterface
+tags: [function]
 ```
 
 ```Go
@@ -368,6 +387,7 @@ func NewInterface() Interface
 
 ```
 searchKey: testdata.X
+tags: [struct]
 ```
 
 ```Go
@@ -384,6 +404,7 @@ And confusing
 
 ```
 searchKey: testdata.Y
+tags: [struct]
 ```
 
 ```Go
@@ -398,6 +419,7 @@ Go can be fun
 
 ```
 searchKey: testdata.Inner
+tags: [struct]
 ```
 
 ```Go
@@ -412,6 +434,7 @@ type Inner struct {
 
 ```
 searchKey: testdata.Outer
+tags: [struct]
 ```
 
 ```Go
@@ -425,6 +448,7 @@ type Outer struct {
 
 ```
 searchKey: testdata.TestInterface
+tags: [interface]
 ```
 
 ```Go
@@ -440,6 +464,7 @@ TestInterface is an interface used for testing.
 
 ```
 searchKey: testdata.TestStruct
+tags: [struct]
 ```
 
 ```Go
@@ -469,6 +494,7 @@ TestStruct is a struct used for testing.
 
 ```
 searchKey: testdata.TestStruct.Doer
+tags: [method]
 ```
 
 ```Go
@@ -481,6 +507,7 @@ Doer is similar to the test interface (but not the same).
 
 ```
 searchKey: testdata.TestEmptyStruct
+tags: [struct]
 ```
 
 ```Go
@@ -491,6 +518,7 @@ type TestEmptyStruct struct{}
 
 ```
 searchKey: testdata.StringAlias
+tags: [string]
 ```
 
 ```Go
@@ -501,6 +529,7 @@ type StringAlias string
 
 ```
 searchKey: testdata.StructTagRegression
+tags: [struct]
 ```
 
 ```Go
@@ -517,6 +546,7 @@ See [https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1a
 
 ```
 searchKey: testdata.TestEqualsStruct
+tags: [struct]
 ```
 
 ```Go
@@ -529,6 +559,7 @@ type TestEqualsStruct = struct {
 
 ```
 searchKey: testdata.ShellStruct
+tags: [struct]
 ```
 
 ```Go
@@ -544,6 +575,7 @@ type ShellStruct struct {
 
 ```
 searchKey: testdata.InnerStruct
+tags: [struct]
 ```
 
 ```Go
@@ -554,6 +586,7 @@ type InnerStruct struct{}
 
 ```
 searchKey: testdata.ParallelizableFunc
+tags: [function]
 ```
 
 ```Go
@@ -566,6 +599,7 @@ ParallelizableFunc is a function that can be called concurrently with other inst
 
 ```
 searchKey: testdata.SecretBurger
+tags: [struct]
 ```
 
 ```Go
@@ -578,6 +612,7 @@ Type aliased doc
 
 ```
 searchKey: testdata.BadBurger
+tags: [struct]
 ```
 
 ```Go
@@ -589,14 +624,14 @@ type BadBurger = struct {
 ## <a id="func" href="#func">Functions</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="useOfCompositeStructs" href="#useOfCompositeStructs">func useOfCompositeStructs()</a>
 
 ```
 searchKey: testdata.useOfCompositeStructs
-tags: [private]
+tags: [function private]
 ```
 
 ```Go
@@ -607,6 +642,7 @@ func useOfCompositeStructs()
 
 ```
 searchKey: testdata.Parallel
+tags: [method]
 ```
 
 ```Go
@@ -619,6 +655,7 @@ Parallel invokes each of the given parallelizable functions in their own gorouti
 
 ```
 searchKey: testdata.Switch
+tags: [method]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/secret.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/secret.json
@@ -5,6 +5,7 @@
     "newPage": true,
     "searchKey": "internal/secret",
     "tags": [
+      "package",
       "private"
     ]
   },
@@ -25,6 +26,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -44,7 +46,10 @@
                 "identifier": "SecretScore",
                 "newPage": false,
                 "searchKey": "secret.SecretScore",
-                "tags": null
+                "tags": [
+                  "constant",
+                  "number"
+                ]
               },
               "label": {
                 "kind": "plaintext",
@@ -68,6 +73,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -87,7 +93,9 @@
                 "identifier": "Burger",
                 "newPage": false,
                 "searchKey": "secret.Burger",
-                "tags": null
+                "tags": [
+                  "struct"
+                ]
               },
               "label": {
                 "kind": "plaintext",

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/secret.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/secret.md
@@ -13,13 +13,14 @@ secret is a package that holds secrets.
 ## <a id="const" href="#const">Constants</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="SecretScore" href="#SecretScore">const SecretScore</a>
 
 ```
 searchKey: secret.SecretScore
+tags: [constant number]
 ```
 
 ```Go
@@ -31,13 +32,14 @@ SecretScore is like score but _secret_.
 ## <a id="type" href="#type">Types</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="Burger" href="#Burger">type Burger struct</a>
 
 ```
 searchKey: secret.Burger
+tags: [struct]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/notests.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/notests.json
@@ -5,6 +5,7 @@
     "newPage": true,
     "searchKey": "internal/shouldvisit/notests",
     "tags": [
+      "package",
       "private"
     ]
   },
@@ -25,6 +26,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -45,6 +47,7 @@
                 "newPage": false,
                 "searchKey": "notests.foo",
                 "tags": [
+                  "function",
                   "private"
                 ]
               },

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/notests.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/notests.md
@@ -11,14 +11,14 @@ This package has no tests.
 ## <a id="func" href="#func">Functions</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="foo" href="#foo">func foo() bool</a>
 
 ```
 searchKey: notests.foo
-tags: [private]
+tags: [function private]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.json
@@ -5,6 +5,7 @@
     "newPage": true,
     "searchKey": "internal/shouldvisit/tests",
     "tags": [
+      "package",
       "private"
     ]
   },
@@ -25,6 +26,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -45,6 +47,7 @@
                 "newPage": false,
                 "searchKey": "tests.foo",
                 "tags": [
+                  "function",
                   "private"
                 ]
               },
@@ -67,6 +70,7 @@
                 "newPage": false,
                 "searchKey": "tests.TestFoo",
                 "tags": [
+                  "method",
                   "private"
                 ]
               },

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.md
@@ -12,14 +12,14 @@ This package has tests.
 ## <a id="func" href="#func">Functions</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="foo" href="#foo">func foo() bool</a>
 
 ```
 searchKey: tests.foo
-tags: [private]
+tags: [function private]
 ```
 
 ```Go
@@ -30,7 +30,7 @@ func foo() bool
 
 ```
 searchKey: tests.TestFoo
-tags: [private]
+tags: [method private]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate.json
@@ -5,6 +5,7 @@
     "newPage": true,
     "searchKey": "internal/shouldvisit/tests_separate",
     "tags": [
+      "package",
       "private"
     ]
   },
@@ -25,6 +26,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -45,6 +47,7 @@
                 "newPage": false,
                 "searchKey": "pkg.foo",
                 "tags": [
+                  "function",
                   "private"
                 ]
               },

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate.md
@@ -11,14 +11,14 @@ This package has tests, but in a separate _test package.
 ## <a id="func" href="#func">Functions</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="foo" href="#foo">func foo() bool</a>
 
 ```
 searchKey: pkg.foo
-tags: [private]
+tags: [function private]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.json
@@ -5,6 +5,7 @@
     "newPage": true,
     "searchKey": "internal/shouldvisit/tests_separate_test",
     "tags": [
+      "package",
       "private"
     ]
   },
@@ -25,6 +26,7 @@
           "newPage": false,
           "searchKey": "",
           "tags": [
+            "package",
             "private"
           ]
         },
@@ -45,6 +47,7 @@
                 "newPage": false,
                 "searchKey": "pkg_test.TestFoo",
                 "tags": [
+                  "method",
                   "private"
                 ]
               },

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.md
@@ -9,14 +9,14 @@
 ## <a id="func" href="#func">Functions</a>
 
 ```
-tags: [private]
+tags: [package private]
 ```
 
 ### <a id="TestFoo" href="#TestFoo">func TestFoo(t *testing.T)</a>
 
 ```
 searchKey: pkg_test.TestFoo
-tags: [private]
+tags: [method private]
 ```
 
 ```Go


### PR DESCRIPTION
This implements https://github.com/sourcegraph/sourcegraph/pull/22327 by causing us to tag documentation for e.g. symbols with more information about the type of symbol being described. e.g. for a `const foo = 5` we now emit tags `[constant number private]` to signal that it is a constant, a number, and a private symbol.

These tags are useful for differentiating things in the UI with e.g. icons, as well as for filtering and searching documentation to just the kinds of things you are interested in.

Helps https://github.com/sourcegraph/sourcegraph/issues/22326