### PR TITLE
API docs: sort all symbols in exported-first, alphabetical order

### DIFF
--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
@@ -44,6 +44,29 @@
         "children": [
           {
             "node": {
+              "pathID": "/#AliasedString",
+              "documentation": {
+                "identifier": "AliasedString",
+                "newPage": false,
+                "searchKey": "testdata.AliasedString",
+                "tags": [
+                  "constant",
+                  "string"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "const AliasedString"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nconst AliasedString StringAlias = \"foobar\"\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
               "pathID": "/#Const",
               "documentation": {
                 "identifier": "Const",
@@ -113,11 +136,11 @@
           },
           {
             "node": {
-              "pathID": "/#Score",
+              "pathID": "/#ConstMath",
               "documentation": {
-                "identifier": "Score",
+                "identifier": "ConstMath",
                 "newPage": false,
-                "searchKey": "testdata.Score",
+                "searchKey": "testdata.ConstMath",
                 "tags": [
                   "constant",
                   "number"
@@ -125,58 +148,11 @@
               },
               "label": {
                 "kind": "plaintext",
-                "value": "const Score"
+                "value": "const ConstMath"
               },
               "detail": {
                 "kind": "markdown",
-                "value": "```Go\nconst Score = uint64(42)\n```\n\nScore is just a hardcoded number. \n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#secretScore",
-              "documentation": {
-                "identifier": "secretScore",
-                "newPage": false,
-                "searchKey": "testdata.secretScore",
-                "tags": [
-                  "constant",
-                  "number",
-                  "private"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "const secretScore"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\nconst secretScore = secret.SecretScore\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#SomeString",
-              "documentation": {
-                "identifier": "SomeString",
-                "newPage": false,
-                "searchKey": "testdata.SomeString",
-                "tags": [
-                  "constant",
-                  "string"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "const SomeString"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\nconst SomeString = \"foobar\"\n```\n\n"
+                "value": "```Go\nconst ConstMath = 1 + (2+3)*5\n```\n\n"
               },
               "children": null
             }
@@ -206,11 +182,11 @@
           },
           {
             "node": {
-              "pathID": "/#ConstMath",
+              "pathID": "/#Score",
               "documentation": {
-                "identifier": "ConstMath",
+                "identifier": "Score",
                 "newPage": false,
-                "searchKey": "testdata.ConstMath",
+                "searchKey": "testdata.Score",
                 "tags": [
                   "constant",
                   "number"
@@ -218,22 +194,22 @@
               },
               "label": {
                 "kind": "plaintext",
-                "value": "const ConstMath"
+                "value": "const Score"
               },
               "detail": {
                 "kind": "markdown",
-                "value": "```Go\nconst ConstMath = 1 + (2+3)*5\n```\n\n"
+                "value": "```Go\nconst Score = uint64(42)\n```\n\nScore is just a hardcoded number. \n\n"
               },
               "children": null
             }
           },
           {
             "node": {
-              "pathID": "/#AliasedString",
+              "pathID": "/#SomeString",
               "documentation": {
-                "identifier": "AliasedString",
+                "identifier": "SomeString",
                 "newPage": false,
-                "searchKey": "testdata.AliasedString",
+                "searchKey": "testdata.SomeString",
                 "tags": [
                   "constant",
                   "string"
@@ -241,11 +217,35 @@
               },
               "label": {
                 "kind": "plaintext",
-                "value": "const AliasedString"
+                "value": "const SomeString"
               },
               "detail": {
                 "kind": "markdown",
-                "value": "```Go\nconst AliasedString StringAlias = \"foobar\"\n```\n\n"
+                "value": "```Go\nconst SomeString = \"foobar\"\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#secretScore",
+              "documentation": {
+                "identifier": "secretScore",
+                "newPage": false,
+                "searchKey": "testdata.secretScore",
+                "tags": [
+                  "constant",
+                  "number",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "const secretScore"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nconst secretScore = secret.SecretScore\n```\n\n"
               },
               "children": null
             }
@@ -276,6 +276,29 @@
         "children": [
           {
             "node": {
+              "pathID": "/#BigVar",
+              "documentation": {
+                "identifier": "BigVar",
+                "newPage": false,
+                "searchKey": "testdata.BigVar",
+                "tags": [
+                  "variable",
+                  "interface"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "var BigVar"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nvar BigVar Interface = ...\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
               "pathID": "/#Var",
               "documentation": {
                 "identifier": "Var",
@@ -293,6 +316,52 @@
               "detail": {
                 "kind": "markdown",
                 "value": "```Go\nvar Var Interface = &Struct{Field: \"bar!\"}\n```\n\nVar is a variable interface. \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#VarBlock1",
+              "documentation": {
+                "identifier": "VarBlock1",
+                "newPage": false,
+                "searchKey": "testdata.VarBlock1",
+                "tags": [
+                  "variable",
+                  "string"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "var VarBlock1"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nvar VarBlock1 = \"if you're reading this\"\n```\n\nWhat are docs, really? I can't say for sure, I don't write any. But look, a CAT! \n\n```\n      |\\      _,,,---,,_\nZZZzz /,`.-'`'    -.  ;-;;,_\n     |,4-  ) )-,_. ,\\ (  `'-'\n    '---''(_/--'  `-'\\_)\n\n```\nIt's sleeping! Some people write that as `sleeping` but Markdown isn't allowed in Go docstrings, right? right?! \n\nThis has some docs \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#VarBlock2",
+              "documentation": {
+                "identifier": "VarBlock2",
+                "newPage": false,
+                "searchKey": "testdata.VarBlock2",
+                "tags": [
+                  "variable",
+                  "string"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "var VarBlock2"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nvar VarBlock2 = \"hi\"\n```\n\nWhat are docs, really? I can't say for sure, I don't write any. But look, a CAT! \n\n```\n      |\\      _,,,---,,_\nZZZzz /,`.-'`'    -.  ;-;;,_\n     |,4-  ) )-,_. ,\\ (  `'-'\n    '---''(_/--'  `-'\\_)\n\n```\nIt's sleeping! Some people write that as `sleeping` but Markdown isn't allowed in Go docstrings, right? right?! \n\n"
               },
               "children": null
             }
@@ -344,75 +413,6 @@
               },
               "children": null
             }
-          },
-          {
-            "node": {
-              "pathID": "/#BigVar",
-              "documentation": {
-                "identifier": "BigVar",
-                "newPage": false,
-                "searchKey": "testdata.BigVar",
-                "tags": [
-                  "variable",
-                  "interface"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "var BigVar"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\nvar BigVar Interface = ...\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#VarBlock1",
-              "documentation": {
-                "identifier": "VarBlock1",
-                "newPage": false,
-                "searchKey": "testdata.VarBlock1",
-                "tags": [
-                  "variable",
-                  "string"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "var VarBlock1"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\nvar VarBlock1 = \"if you're reading this\"\n```\n\nWhat are docs, really? I can't say for sure, I don't write any. But look, a CAT! \n\n```\n      |\\      _,,,---,,_\nZZZzz /,`.-'`'    -.  ;-;;,_\n     |,4-  ) )-,_. ,\\ (  `'-'\n    '---''(_/--'  `-'\\_)\n\n```\nIt's sleeping! Some people write that as `sleeping` but Markdown isn't allowed in Go docstrings, right? right?! \n\nThis has some docs \n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#VarBlock2",
-              "documentation": {
-                "identifier": "VarBlock2",
-                "newPage": false,
-                "searchKey": "testdata.VarBlock2",
-                "tags": [
-                  "variable",
-                  "string"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "var VarBlock2"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\nvar VarBlock2 = \"hi\"\n```\n\nWhat are docs, really? I can't say for sure, I don't write any. But look, a CAT! \n\n```\n      |\\      _,,,---,,_\nZZZzz /,`.-'`'    -.  ;-;;,_\n     |,4-  ) )-,_. ,\\ (  `'-'\n    '---''(_/--'  `-'\\_)\n\n```\nIt's sleeping! Some people write that as `sleeping` but Markdown isn't allowed in Go docstrings, right? right?! \n\n"
-              },
-              "children": null
-            }
           }
         ]
       }
@@ -440,6 +440,28 @@
         "children": [
           {
             "node": {
+              "pathID": "/#BadBurger",
+              "documentation": {
+                "identifier": "BadBurger",
+                "newPage": false,
+                "searchKey": "testdata.BadBurger",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type BadBurger struct"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype BadBurger = struct {\n\tField string\n}\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
               "pathID": "/#Embedded",
               "documentation": {
                 "identifier": "Embedded",
@@ -462,91 +484,46 @@
           },
           {
             "node": {
-              "pathID": "/#Struct",
+              "pathID": "/#Inner",
               "documentation": {
-                "identifier": "Struct",
+                "identifier": "Inner",
                 "newPage": false,
-                "searchKey": "testdata.Struct",
+                "searchKey": "testdata.Inner",
                 "tags": [
                   "struct"
                 ]
               },
               "label": {
                 "kind": "plaintext",
-                "value": "type Struct struct"
+                "value": "type Inner struct"
               },
               "detail": {
                 "kind": "markdown",
-                "value": "```Go\ntype Struct struct {\n\t*Embedded\n\tField     string\n\tAnonymous struct {\n\t\tFieldA int\n\t\tFieldB int\n\t\tFieldC int\n\t}\n}\n```\n\n"
+                "value": "```Go\ntype Inner struct {\n\tX int\n\tY int\n\tZ int\n}\n```\n\n"
               },
-              "children": [
-                {
-                  "node": {
-                    "pathID": "/#Struct.StructMethod",
-                    "documentation": {
-                      "identifier": "Struct.StructMethod",
-                      "newPage": false,
-                      "searchKey": "testdata.Struct.StructMethod",
-                      "tags": [
-                        "function"
-                      ]
-                    },
-                    "label": {
-                      "kind": "plaintext",
-                      "value": "func (s *Struct) StructMethod()"
-                    },
-                    "detail": {
-                      "kind": "markdown",
-                      "value": "```Go\nfunc (s *Struct) StructMethod()\n```\n\nStructMethod has some docs! \n\n"
-                    },
-                    "children": null
-                  }
-                },
-                {
-                  "node": {
-                    "pathID": "/#Struct.ImplementsInterface",
-                    "documentation": {
-                      "identifier": "Struct.ImplementsInterface",
-                      "newPage": false,
-                      "searchKey": "testdata.Struct.ImplementsInterface",
-                      "tags": [
-                        "function"
-                      ]
-                    },
-                    "label": {
-                      "kind": "plaintext",
-                      "value": "func (s *Struct) ImplementsInterface() string"
-                    },
-                    "detail": {
-                      "kind": "markdown",
-                      "value": "```Go\nfunc (s *Struct) ImplementsInterface() string\n```\n\n"
-                    },
-                    "children": null
-                  }
-                },
-                {
-                  "node": {
-                    "pathID": "/#Struct.MachineLearning",
-                    "documentation": {
-                      "identifier": "Struct.MachineLearning",
-                      "newPage": false,
-                      "searchKey": "testdata.Struct.MachineLearning",
-                      "tags": [
-                        "method"
-                      ]
-                    },
-                    "label": {
-                      "kind": "plaintext",
-                      "value": "func (s *Struct) MachineLearning(param1 float32,..."
-                    },
-                    "detail": {
-                      "kind": "markdown",
-                      "value": "```Go\nfunc (s *Struct) MachineLearning(\n\tparam1 float32,\n\n\thyperparam2 float32,\n\thyperparam3 float32,\n) float32\n```\n\n"
-                    },
-                    "children": null
-                  }
-                }
-              ]
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#InnerStruct",
+              "documentation": {
+                "identifier": "InnerStruct",
+                "newPage": false,
+                "searchKey": "testdata.InnerStruct",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type InnerStruct struct{}"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype InnerStruct struct{}\n```\n\n"
+              },
+              "children": null
             }
           },
           {
@@ -596,72 +573,6 @@
           },
           {
             "node": {
-              "pathID": "/#X",
-              "documentation": {
-                "identifier": "X",
-                "newPage": false,
-                "searchKey": "testdata.X",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type X struct"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype X struct {\n\tbar string\n}\n```\n\nGo can be fun \n\nAnd confusing \n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#Y",
-              "documentation": {
-                "identifier": "Y",
-                "newPage": false,
-                "searchKey": "testdata.Y",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type Y struct"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype Y struct {\n\tbaz float\n}\n```\n\nGo can be fun \n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#Inner",
-              "documentation": {
-                "identifier": "Inner",
-                "newPage": false,
-                "searchKey": "testdata.Inner",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type Inner struct"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype Inner struct {\n\tX int\n\tY int\n\tZ int\n}\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
               "pathID": "/#Outer",
               "documentation": {
                 "identifier": "Outer",
@@ -678,6 +589,249 @@
               "detail": {
                 "kind": "markdown",
                 "value": "```Go\ntype Outer struct {\n\tInner\n\tW int\n}\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#ParallelizableFunc",
+              "documentation": {
+                "identifier": "ParallelizableFunc",
+                "newPage": false,
+                "searchKey": "testdata.ParallelizableFunc",
+                "tags": [
+                  "function"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type ParallelizableFunc func(ctx context.Context) error"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype ParallelizableFunc func(ctx context.Context) error\n```\n\nParallelizableFunc is a function that can be called concurrently with other instances of this function type. \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#SecretBurger",
+              "documentation": {
+                "identifier": "SecretBurger",
+                "newPage": false,
+                "searchKey": "testdata.SecretBurger",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type SecretBurger secret.Burger"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype SecretBurger = secret.Burger\n```\n\nType aliased doc \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#ShellStruct",
+              "documentation": {
+                "identifier": "ShellStruct",
+                "newPage": false,
+                "searchKey": "testdata.ShellStruct",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type ShellStruct struct"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype ShellStruct struct {\n\t// Ensure this field comes before the definition\n\t// so that we grab the correct one in our unit\n\t// tests.\n\tInnerStruct\n}\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#StringAlias",
+              "documentation": {
+                "identifier": "StringAlias",
+                "newPage": false,
+                "searchKey": "testdata.StringAlias",
+                "tags": [
+                  "string"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type StringAlias string"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype StringAlias string\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#Struct",
+              "documentation": {
+                "identifier": "Struct",
+                "newPage": false,
+                "searchKey": "testdata.Struct",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type Struct struct"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype Struct struct {\n\t*Embedded\n\tField     string\n\tAnonymous struct {\n\t\tFieldA int\n\t\tFieldB int\n\t\tFieldC int\n\t}\n}\n```\n\n"
+              },
+              "children": [
+                {
+                  "node": {
+                    "pathID": "/#Struct.ImplementsInterface",
+                    "documentation": {
+                      "identifier": "Struct.ImplementsInterface",
+                      "newPage": false,
+                      "searchKey": "testdata.Struct.ImplementsInterface",
+                      "tags": [
+                        "function"
+                      ]
+                    },
+                    "label": {
+                      "kind": "plaintext",
+                      "value": "func (s *Struct) ImplementsInterface() string"
+                    },
+                    "detail": {
+                      "kind": "markdown",
+                      "value": "```Go\nfunc (s *Struct) ImplementsInterface() string\n```\n\n"
+                    },
+                    "children": null
+                  }
+                },
+                {
+                  "node": {
+                    "pathID": "/#Struct.MachineLearning",
+                    "documentation": {
+                      "identifier": "Struct.MachineLearning",
+                      "newPage": false,
+                      "searchKey": "testdata.Struct.MachineLearning",
+                      "tags": [
+                        "method"
+                      ]
+                    },
+                    "label": {
+                      "kind": "plaintext",
+                      "value": "func (s *Struct) MachineLearning(param1 float32,..."
+                    },
+                    "detail": {
+                      "kind": "markdown",
+                      "value": "```Go\nfunc (s *Struct) MachineLearning(\n\tparam1 float32,\n\n\thyperparam2 float32,\n\thyperparam3 float32,\n) float32\n```\n\n"
+                    },
+                    "children": null
+                  }
+                },
+                {
+                  "node": {
+                    "pathID": "/#Struct.StructMethod",
+                    "documentation": {
+                      "identifier": "Struct.StructMethod",
+                      "newPage": false,
+                      "searchKey": "testdata.Struct.StructMethod",
+                      "tags": [
+                        "function"
+                      ]
+                    },
+                    "label": {
+                      "kind": "plaintext",
+                      "value": "func (s *Struct) StructMethod()"
+                    },
+                    "detail": {
+                      "kind": "markdown",
+                      "value": "```Go\nfunc (s *Struct) StructMethod()\n```\n\nStructMethod has some docs! \n\n"
+                    },
+                    "children": null
+                  }
+                }
+              ]
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#StructTagRegression",
+              "documentation": {
+                "identifier": "StructTagRegression",
+                "newPage": false,
+                "searchKey": "testdata.StructTagRegression",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type StructTagRegression struct"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype StructTagRegression struct {\n\tValue int `key:\",range=[:}\"`\n}\n```\n\nStructTagRegression is a struct that caused panic in the wild. Added here to support a regression test. \n\nSee [https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272](https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272). \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#TestEmptyStruct",
+              "documentation": {
+                "identifier": "TestEmptyStruct",
+                "newPage": false,
+                "searchKey": "testdata.TestEmptyStruct",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type TestEmptyStruct struct{}"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype TestEmptyStruct struct{}\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#TestEqualsStruct",
+              "documentation": {
+                "identifier": "TestEqualsStruct",
+                "newPage": false,
+                "searchKey": "testdata.TestEqualsStruct",
+                "tags": [
+                  "struct"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "type TestEqualsStruct struct"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\ntype TestEqualsStruct = struct {\n\tValue int\n}\n```\n\n"
               },
               "children": null
             }
@@ -751,198 +905,44 @@
           },
           {
             "node": {
-              "pathID": "/#TestEmptyStruct",
+              "pathID": "/#X",
               "documentation": {
-                "identifier": "TestEmptyStruct",
+                "identifier": "X",
                 "newPage": false,
-                "searchKey": "testdata.TestEmptyStruct",
+                "searchKey": "testdata.X",
                 "tags": [
                   "struct"
                 ]
               },
               "label": {
                 "kind": "plaintext",
-                "value": "type TestEmptyStruct struct{}"
+                "value": "type X struct"
               },
               "detail": {
                 "kind": "markdown",
-                "value": "```Go\ntype TestEmptyStruct struct{}\n```\n\n"
+                "value": "```Go\ntype X struct {\n\tbar string\n}\n```\n\nGo can be fun \n\nAnd confusing \n\n"
               },
               "children": null
             }
           },
           {
             "node": {
-              "pathID": "/#StringAlias",
+              "pathID": "/#Y",
               "documentation": {
-                "identifier": "StringAlias",
+                "identifier": "Y",
                 "newPage": false,
-                "searchKey": "testdata.StringAlias",
-                "tags": [
-                  "string"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type StringAlias string"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype StringAlias string\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#StructTagRegression",
-              "documentation": {
-                "identifier": "StructTagRegression",
-                "newPage": false,
-                "searchKey": "testdata.StructTagRegression",
+                "searchKey": "testdata.Y",
                 "tags": [
                   "struct"
                 ]
               },
               "label": {
                 "kind": "plaintext",
-                "value": "type StructTagRegression struct"
+                "value": "type Y struct"
               },
               "detail": {
                 "kind": "markdown",
-                "value": "```Go\ntype StructTagRegression struct {\n\tValue int `key:\",range=[:}\"`\n}\n```\n\nStructTagRegression is a struct that caused panic in the wild. Added here to support a regression test. \n\nSee [https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272](https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272). \n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#TestEqualsStruct",
-              "documentation": {
-                "identifier": "TestEqualsStruct",
-                "newPage": false,
-                "searchKey": "testdata.TestEqualsStruct",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type TestEqualsStruct struct"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype TestEqualsStruct = struct {\n\tValue int\n}\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#ShellStruct",
-              "documentation": {
-                "identifier": "ShellStruct",
-                "newPage": false,
-                "searchKey": "testdata.ShellStruct",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type ShellStruct struct"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype ShellStruct struct {\n\t// Ensure this field comes before the definition\n\t// so that we grab the correct one in our unit\n\t// tests.\n\tInnerStruct\n}\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#InnerStruct",
-              "documentation": {
-                "identifier": "InnerStruct",
-                "newPage": false,
-                "searchKey": "testdata.InnerStruct",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type InnerStruct struct{}"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype InnerStruct struct{}\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#ParallelizableFunc",
-              "documentation": {
-                "identifier": "ParallelizableFunc",
-                "newPage": false,
-                "searchKey": "testdata.ParallelizableFunc",
-                "tags": [
-                  "function"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type ParallelizableFunc func(ctx context.Context) error"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype ParallelizableFunc func(ctx context.Context) error\n```\n\nParallelizableFunc is a function that can be called concurrently with other instances of this function type. \n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#SecretBurger",
-              "documentation": {
-                "identifier": "SecretBurger",
-                "newPage": false,
-                "searchKey": "testdata.SecretBurger",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type SecretBurger secret.Burger"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype SecretBurger = secret.Burger\n```\n\nType aliased doc \n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
-              "pathID": "/#BadBurger",
-              "documentation": {
-                "identifier": "BadBurger",
-                "newPage": false,
-                "searchKey": "testdata.BadBurger",
-                "tags": [
-                  "struct"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "type BadBurger struct"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\ntype BadBurger = struct {\n\tField string\n}\n```\n\n"
+                "value": "```Go\ntype Y struct {\n\tbaz float\n}\n```\n\nGo can be fun \n\n"
               },
               "children": null
             }
@@ -971,29 +971,6 @@
           "value": ""
         },
         "children": [
-          {
-            "node": {
-              "pathID": "/#useOfCompositeStructs",
-              "documentation": {
-                "identifier": "useOfCompositeStructs",
-                "newPage": false,
-                "searchKey": "testdata.useOfCompositeStructs",
-                "tags": [
-                  "function",
-                  "private"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "func useOfCompositeStructs()"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\nfunc useOfCompositeStructs()\n```\n\n"
-              },
-              "children": null
-            }
-          },
           {
             "node": {
               "pathID": "/#Parallel",
@@ -1034,6 +1011,29 @@
               "detail": {
                 "kind": "markdown",
                 "value": "```Go\nfunc Switch(interfaceValue interface{}) bool\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/#useOfCompositeStructs",
+              "documentation": {
+                "identifier": "useOfCompositeStructs",
+                "newPage": false,
+                "searchKey": "testdata.useOfCompositeStructs",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func useOfCompositeStructs()"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc useOfCompositeStructs()\n```\n\n"
               },
               "children": null
             }

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
@@ -10,56 +10,67 @@ testdata is a small package containing sample Go source code used for testing th
   * [internal](internal.md)
   * [duplicate_path_id](duplicate_path_id.md)
 * [Constants](#const)
+    * [const AliasedString](#AliasedString)
     * [const Const](#Const)
     * [const ConstBlock1](#ConstBlock1)
     * [const ConstBlock2](#ConstBlock2)
-    * [const Score](#Score)
-    * [const secretScore](#secretScore)
-    * [const SomeString](#SomeString)
-    * [const LongString](#LongString)
     * [const ConstMath](#ConstMath)
-    * [const AliasedString](#AliasedString)
+    * [const LongString](#LongString)
+    * [const Score](#Score)
+    * [const SomeString](#SomeString)
+    * [const secretScore](#secretScore)
 * [Variables](#var)
-    * [var Var](#Var)
-    * [var unexportedVar](#unexportedVar)
-    * [var x](#x)
     * [var BigVar](#BigVar)
+    * [var Var](#Var)
     * [var VarBlock1](#VarBlock1)
     * [var VarBlock2](#VarBlock2)
+    * [var unexportedVar](#unexportedVar)
+    * [var x](#x)
 * [Types](#type)
+    * [type BadBurger struct](#BadBurger)
     * [type Embedded struct](#Embedded)
-    * [type Struct struct](#Struct)
-        * [func (s *Struct) StructMethod()](#Struct.StructMethod)
-        * [func (s *Struct) ImplementsInterface() string](#Struct.ImplementsInterface)
-        * [func (s *Struct) MachineLearning(param1 float32,...](#Struct.MachineLearning)
+    * [type Inner struct](#Inner)
+    * [type InnerStruct struct{}](#InnerStruct)
     * [type Interface interface](#Interface)
         * [func NewInterface() Interface](#NewInterface)
-    * [type X struct](#X)
-    * [type Y struct](#Y)
-    * [type Inner struct](#Inner)
     * [type Outer struct](#Outer)
+    * [type ParallelizableFunc func(ctx context.Context) error](#ParallelizableFunc)
+    * [type SecretBurger secret.Burger](#SecretBurger)
+    * [type ShellStruct struct](#ShellStruct)
+    * [type StringAlias string](#StringAlias)
+    * [type Struct struct](#Struct)
+        * [func (s *Struct) ImplementsInterface() string](#Struct.ImplementsInterface)
+        * [func (s *Struct) MachineLearning(param1 float32,...](#Struct.MachineLearning)
+        * [func (s *Struct) StructMethod()](#Struct.StructMethod)
+    * [type StructTagRegression struct](#StructTagRegression)
+    * [type TestEmptyStruct struct{}](#TestEmptyStruct)
+    * [type TestEqualsStruct struct](#TestEqualsStruct)
     * [type TestInterface interface](#TestInterface)
     * [type TestStruct struct](#TestStruct)
         * [func (ts *TestStruct) Doer(ctx context.Context, data string) (score int, err error)](#TestStruct.Doer)
-    * [type TestEmptyStruct struct{}](#TestEmptyStruct)
-    * [type StringAlias string](#StringAlias)
-    * [type StructTagRegression struct](#StructTagRegression)
-    * [type TestEqualsStruct struct](#TestEqualsStruct)
-    * [type ShellStruct struct](#ShellStruct)
-    * [type InnerStruct struct{}](#InnerStruct)
-    * [type ParallelizableFunc func(ctx context.Context) error](#ParallelizableFunc)
-    * [type SecretBurger secret.Burger](#SecretBurger)
-    * [type BadBurger struct](#BadBurger)
+    * [type X struct](#X)
+    * [type Y struct](#Y)
 * [Functions](#func)
-    * [func useOfCompositeStructs()](#useOfCompositeStructs)
     * [func Parallel(ctx context.Context, fns ...ParallelizableFunc) error](#Parallel)
     * [func Switch(interfaceValue interface{}) bool](#Switch)
+    * [func useOfCompositeStructs()](#useOfCompositeStructs)
 
 
 ## <a id="const" href="#const">Constants</a>
 
 ```
 tags: [package private]
+```
+
+### <a id="AliasedString" href="#AliasedString">const AliasedString</a>
+
+```
+searchKey: testdata.AliasedString
+tags: [constant string]
+```
+
+```Go
+const AliasedString StringAlias = "foobar"
 ```
 
 ### <a id="Const" href="#Const">const Const</a>
@@ -105,39 +116,15 @@ Docs for the const block itself.
 
 ConstBlock2 is a constant in a block. 
 
-### <a id="Score" href="#Score">const Score</a>
+### <a id="ConstMath" href="#ConstMath">const ConstMath</a>
 
 ```
-searchKey: testdata.Score
+searchKey: testdata.ConstMath
 tags: [constant number]
 ```
 
 ```Go
-const Score = uint64(42)
-```
-
-Score is just a hardcoded number. 
-
-### <a id="secretScore" href="#secretScore">const secretScore</a>
-
-```
-searchKey: testdata.secretScore
-tags: [constant number private]
-```
-
-```Go
-const secretScore = secret.SecretScore
-```
-
-### <a id="SomeString" href="#SomeString">const SomeString</a>
-
-```
-searchKey: testdata.SomeString
-tags: [constant string]
-```
-
-```Go
-const SomeString = "foobar"
+const ConstMath = 1 + (2+3)*5
 ```
 
 ### <a id="LongString" href="#LongString">const LongString</a>
@@ -151,32 +138,56 @@ tags: [constant string]
 const LongString = ...
 ```
 
-### <a id="ConstMath" href="#ConstMath">const ConstMath</a>
+### <a id="Score" href="#Score">const Score</a>
 
 ```
-searchKey: testdata.ConstMath
+searchKey: testdata.Score
 tags: [constant number]
 ```
 
 ```Go
-const ConstMath = 1 + (2+3)*5
+const Score = uint64(42)
 ```
 
-### <a id="AliasedString" href="#AliasedString">const AliasedString</a>
+Score is just a hardcoded number. 
+
+### <a id="SomeString" href="#SomeString">const SomeString</a>
 
 ```
-searchKey: testdata.AliasedString
+searchKey: testdata.SomeString
 tags: [constant string]
 ```
 
 ```Go
-const AliasedString StringAlias = "foobar"
+const SomeString = "foobar"
+```
+
+### <a id="secretScore" href="#secretScore">const secretScore</a>
+
+```
+searchKey: testdata.secretScore
+tags: [constant number private]
+```
+
+```Go
+const secretScore = secret.SecretScore
 ```
 
 ## <a id="var" href="#var">Variables</a>
 
 ```
 tags: [package private]
+```
+
+### <a id="BigVar" href="#BigVar">var BigVar</a>
+
+```
+searchKey: testdata.BigVar
+tags: [variable interface]
+```
+
+```Go
+var BigVar Interface = ...
 ```
 
 ### <a id="Var" href="#Var">var Var</a>
@@ -191,43 +202,6 @@ var Var Interface = &Struct{Field: "bar!"}
 ```
 
 Var is a variable interface. 
-
-### <a id="unexportedVar" href="#unexportedVar">var unexportedVar</a>
-
-```
-searchKey: testdata.unexportedVar
-tags: [variable interface private]
-```
-
-```Go
-var unexportedVar Interface = &Struct{Field: "bar!"}
-```
-
-unexportedVar is an unexported variable interface. 
-
-### <a id="x" href="#x">var x</a>
-
-```
-searchKey: testdata.x
-tags: [variable interface private]
-```
-
-```Go
-var x error
-```
-
-x has a builtin error type 
-
-### <a id="BigVar" href="#BigVar">var BigVar</a>
-
-```
-searchKey: testdata.BigVar
-tags: [variable interface]
-```
-
-```Go
-var BigVar Interface = ...
-```
 
 ### <a id="VarBlock1" href="#VarBlock1">var VarBlock1</a>
 
@@ -275,10 +249,49 @@ ZZZzz /,`.-'`'    -.  ;-;;,_
 ```
 It's sleeping! Some people write that as `sleeping` but Markdown isn't allowed in Go docstrings, right? right?! 
 
+### <a id="unexportedVar" href="#unexportedVar">var unexportedVar</a>
+
+```
+searchKey: testdata.unexportedVar
+tags: [variable interface private]
+```
+
+```Go
+var unexportedVar Interface = &Struct{Field: "bar!"}
+```
+
+unexportedVar is an unexported variable interface. 
+
+### <a id="x" href="#x">var x</a>
+
+```
+searchKey: testdata.x
+tags: [variable interface private]
+```
+
+```Go
+var x error
+```
+
+x has a builtin error type 
+
 ## <a id="type" href="#type">Types</a>
 
 ```
 tags: [package private]
+```
+
+### <a id="BadBurger" href="#BadBurger">type BadBurger struct</a>
+
+```
+searchKey: testdata.BadBurger
+tags: [struct]
+```
+
+```Go
+type BadBurger = struct {
+	Field string
+}
 ```
 
 ### <a id="Embedded" href="#Embedded">type Embedded struct</a>
@@ -298,63 +311,30 @@ type Embedded struct {
 
 Embedded is a struct, to be embedded in another struct. 
 
-### <a id="Struct" href="#Struct">type Struct struct</a>
+### <a id="Inner" href="#Inner">type Inner struct</a>
 
 ```
-searchKey: testdata.Struct
+searchKey: testdata.Inner
 tags: [struct]
 ```
 
 ```Go
-type Struct struct {
-	*Embedded
-	Field     string
-	Anonymous struct {
-		FieldA int
-		FieldB int
-		FieldC int
-	}
+type Inner struct {
+	X int
+	Y int
+	Z int
 }
 ```
 
-#### <a id="Struct.StructMethod" href="#Struct.StructMethod">func (s *Struct) StructMethod()</a>
+### <a id="InnerStruct" href="#InnerStruct">type InnerStruct struct{}</a>
 
 ```
-searchKey: testdata.Struct.StructMethod
-tags: [function]
-```
-
-```Go
-func (s *Struct) StructMethod()
-```
-
-StructMethod has some docs! 
-
-#### <a id="Struct.ImplementsInterface" href="#Struct.ImplementsInterface">func (s *Struct) ImplementsInterface() string</a>
-
-```
-searchKey: testdata.Struct.ImplementsInterface
-tags: [function]
+searchKey: testdata.InnerStruct
+tags: [struct]
 ```
 
 ```Go
-func (s *Struct) ImplementsInterface() string
-```
-
-#### <a id="Struct.MachineLearning" href="#Struct.MachineLearning">func (s *Struct) MachineLearning(param1 float32,...</a>
-
-```
-searchKey: testdata.Struct.MachineLearning
-tags: [method]
-```
-
-```Go
-func (s *Struct) MachineLearning(
-	param1 float32,
-
-	hyperparam2 float32,
-	hyperparam3 float32,
-) float32
+type InnerStruct struct{}
 ```
 
 ### <a id="Interface" href="#Interface">type Interface interface</a>
@@ -383,53 +363,6 @@ tags: [function]
 func NewInterface() Interface
 ```
 
-### <a id="X" href="#X">type X struct</a>
-
-```
-searchKey: testdata.X
-tags: [struct]
-```
-
-```Go
-type X struct {
-	bar string
-}
-```
-
-Go can be fun 
-
-And confusing 
-
-### <a id="Y" href="#Y">type Y struct</a>
-
-```
-searchKey: testdata.Y
-tags: [struct]
-```
-
-```Go
-type Y struct {
-	baz float
-}
-```
-
-Go can be fun 
-
-### <a id="Inner" href="#Inner">type Inner struct</a>
-
-```
-searchKey: testdata.Inner
-tags: [struct]
-```
-
-```Go
-type Inner struct {
-	X int
-	Y int
-	Z int
-}
-```
-
 ### <a id="Outer" href="#Outer">type Outer struct</a>
 
 ```
@@ -441,6 +374,159 @@ tags: [struct]
 type Outer struct {
 	Inner
 	W int
+}
+```
+
+### <a id="ParallelizableFunc" href="#ParallelizableFunc">type ParallelizableFunc func(ctx context.Context) error</a>
+
+```
+searchKey: testdata.ParallelizableFunc
+tags: [function]
+```
+
+```Go
+type ParallelizableFunc func(ctx context.Context) error
+```
+
+ParallelizableFunc is a function that can be called concurrently with other instances of this function type. 
+
+### <a id="SecretBurger" href="#SecretBurger">type SecretBurger secret.Burger</a>
+
+```
+searchKey: testdata.SecretBurger
+tags: [struct]
+```
+
+```Go
+type SecretBurger = secret.Burger
+```
+
+Type aliased doc 
+
+### <a id="ShellStruct" href="#ShellStruct">type ShellStruct struct</a>
+
+```
+searchKey: testdata.ShellStruct
+tags: [struct]
+```
+
+```Go
+type ShellStruct struct {
+	// Ensure this field comes before the definition
+	// so that we grab the correct one in our unit
+	// tests.
+	InnerStruct
+}
+```
+
+### <a id="StringAlias" href="#StringAlias">type StringAlias string</a>
+
+```
+searchKey: testdata.StringAlias
+tags: [string]
+```
+
+```Go
+type StringAlias string
+```
+
+### <a id="Struct" href="#Struct">type Struct struct</a>
+
+```
+searchKey: testdata.Struct
+tags: [struct]
+```
+
+```Go
+type Struct struct {
+	*Embedded
+	Field     string
+	Anonymous struct {
+		FieldA int
+		FieldB int
+		FieldC int
+	}
+}
+```
+
+#### <a id="Struct.ImplementsInterface" href="#Struct.ImplementsInterface">func (s *Struct) ImplementsInterface() string</a>
+
+```
+searchKey: testdata.Struct.ImplementsInterface
+tags: [function]
+```
+
+```Go
+func (s *Struct) ImplementsInterface() string
+```
+
+#### <a id="Struct.MachineLearning" href="#Struct.MachineLearning">func (s *Struct) MachineLearning(param1 float32,...</a>
+
+```
+searchKey: testdata.Struct.MachineLearning
+tags: [method]
+```
+
+```Go
+func (s *Struct) MachineLearning(
+	param1 float32,
+
+	hyperparam2 float32,
+	hyperparam3 float32,
+) float32
+```
+
+#### <a id="Struct.StructMethod" href="#Struct.StructMethod">func (s *Struct) StructMethod()</a>
+
+```
+searchKey: testdata.Struct.StructMethod
+tags: [function]
+```
+
+```Go
+func (s *Struct) StructMethod()
+```
+
+StructMethod has some docs! 
+
+### <a id="StructTagRegression" href="#StructTagRegression">type StructTagRegression struct</a>
+
+```
+searchKey: testdata.StructTagRegression
+tags: [struct]
+```
+
+```Go
+type StructTagRegression struct {
+	Value int `key:",range=[:}"`
+}
+```
+
+StructTagRegression is a struct that caused panic in the wild. Added here to support a regression test. 
+
+See [https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272](https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272). 
+
+### <a id="TestEmptyStruct" href="#TestEmptyStruct">type TestEmptyStruct struct{}</a>
+
+```
+searchKey: testdata.TestEmptyStruct
+tags: [struct]
+```
+
+```Go
+type TestEmptyStruct struct{}
+```
+
+### <a id="TestEqualsStruct" href="#TestEqualsStruct">type TestEqualsStruct struct</a>
+
+```
+searchKey: testdata.TestEqualsStruct
+tags: [struct]
+```
+
+```Go
+type TestEqualsStruct = struct {
+	Value int
 }
 ```
 
@@ -503,139 +589,42 @@ func (ts *TestStruct) Doer(ctx context.Context, data string) (score int, err err
 
 Doer is similar to the test interface (but not the same). 
 
-### <a id="TestEmptyStruct" href="#TestEmptyStruct">type TestEmptyStruct struct{}</a>
+### <a id="X" href="#X">type X struct</a>
 
 ```
-searchKey: testdata.TestEmptyStruct
+searchKey: testdata.X
 tags: [struct]
 ```
 
 ```Go
-type TestEmptyStruct struct{}
-```
-
-### <a id="StringAlias" href="#StringAlias">type StringAlias string</a>
-
-```
-searchKey: testdata.StringAlias
-tags: [string]
-```
-
-```Go
-type StringAlias string
-```
-
-### <a id="StructTagRegression" href="#StructTagRegression">type StructTagRegression struct</a>
-
-```
-searchKey: testdata.StructTagRegression
-tags: [struct]
-```
-
-```Go
-type StructTagRegression struct {
-	Value int `key:",range=[:}"`
+type X struct {
+	bar string
 }
 ```
 
-StructTagRegression is a struct that caused panic in the wild. Added here to support a regression test. 
+Go can be fun 
 
-See [https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272](https://github.com/tal-tech/go-zero/blob/11dd3d75ecceaa3f5772024fb3f26dec1ada8e9c/core/mapping/unmarshaler_test.go#L2272). 
+And confusing 
 
-### <a id="TestEqualsStruct" href="#TestEqualsStruct">type TestEqualsStruct struct</a>
+### <a id="Y" href="#Y">type Y struct</a>
 
 ```
-searchKey: testdata.TestEqualsStruct
+searchKey: testdata.Y
 tags: [struct]
 ```
 
 ```Go
-type TestEqualsStruct = struct {
-	Value int
+type Y struct {
+	baz float
 }
 ```
 
-### <a id="ShellStruct" href="#ShellStruct">type ShellStruct struct</a>
-
-```
-searchKey: testdata.ShellStruct
-tags: [struct]
-```
-
-```Go
-type ShellStruct struct {
-	// Ensure this field comes before the definition
-	// so that we grab the correct one in our unit
-	// tests.
-	InnerStruct
-}
-```
-
-### <a id="InnerStruct" href="#InnerStruct">type InnerStruct struct{}</a>
-
-```
-searchKey: testdata.InnerStruct
-tags: [struct]
-```
-
-```Go
-type InnerStruct struct{}
-```
-
-### <a id="ParallelizableFunc" href="#ParallelizableFunc">type ParallelizableFunc func(ctx context.Context) error</a>
-
-```
-searchKey: testdata.ParallelizableFunc
-tags: [function]
-```
-
-```Go
-type ParallelizableFunc func(ctx context.Context) error
-```
-
-ParallelizableFunc is a function that can be called concurrently with other instances of this function type. 
-
-### <a id="SecretBurger" href="#SecretBurger">type SecretBurger secret.Burger</a>
-
-```
-searchKey: testdata.SecretBurger
-tags: [struct]
-```
-
-```Go
-type SecretBurger = secret.Burger
-```
-
-Type aliased doc 
-
-### <a id="BadBurger" href="#BadBurger">type BadBurger struct</a>
-
-```
-searchKey: testdata.BadBurger
-tags: [struct]
-```
-
-```Go
-type BadBurger = struct {
-	Field string
-}
-```
+Go can be fun 
 
 ## <a id="func" href="#func">Functions</a>
 
 ```
 tags: [package private]
-```
-
-### <a id="useOfCompositeStructs" href="#useOfCompositeStructs">func useOfCompositeStructs()</a>
-
-```
-searchKey: testdata.useOfCompositeStructs
-tags: [function private]
-```
-
-```Go
-func useOfCompositeStructs()
 ```
 
 ### <a id="Parallel" href="#Parallel">func Parallel(ctx context.Context, fns ...ParallelizableFunc) error</a>
@@ -660,5 +649,16 @@ tags: [method]
 
 ```Go
 func Switch(interfaceValue interface{}) bool
+```
+
+### <a id="useOfCompositeStructs" href="#useOfCompositeStructs">func useOfCompositeStructs()</a>
+
+```
+searchKey: testdata.useOfCompositeStructs
+tags: [function private]
+```
+
+```Go
+func useOfCompositeStructs()
 ```
 

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.json
@@ -41,29 +41,6 @@
         "children": [
           {
             "node": {
-              "pathID": "/internal/shouldvisit/tests#foo",
-              "documentation": {
-                "identifier": "foo",
-                "newPage": false,
-                "searchKey": "tests.foo",
-                "tags": [
-                  "function",
-                  "private"
-                ]
-              },
-              "label": {
-                "kind": "plaintext",
-                "value": "func foo() bool"
-              },
-              "detail": {
-                "kind": "markdown",
-                "value": "```Go\nfunc foo() bool\n```\n\n"
-              },
-              "children": null
-            }
-          },
-          {
-            "node": {
               "pathID": "/internal/shouldvisit/tests#TestFoo",
               "documentation": {
                 "identifier": "TestFoo",
@@ -81,6 +58,29 @@
               "detail": {
                 "kind": "markdown",
                 "value": "```Go\nfunc TestFoo(t *testing.T)\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/internal/shouldvisit/tests#foo",
+              "documentation": {
+                "identifier": "foo",
+                "newPage": false,
+                "searchKey": "tests.foo",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func foo() bool"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc foo() bool\n```\n\n"
               },
               "children": null
             }

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.md
@@ -5,25 +5,14 @@ This package has tests.
 ## Index
 
 * [Functions](#func)
-    * [func foo() bool](#foo)
     * [func TestFoo(t *testing.T)](#TestFoo)
+    * [func foo() bool](#foo)
 
 
 ## <a id="func" href="#func">Functions</a>
 
 ```
 tags: [package private]
-```
-
-### <a id="foo" href="#foo">func foo() bool</a>
-
-```
-searchKey: tests.foo
-tags: [function private]
-```
-
-```Go
-func foo() bool
 ```
 
 ### <a id="TestFoo" href="#TestFoo">func TestFoo(t *testing.T)</a>
@@ -35,5 +24,16 @@ tags: [method private]
 
 ```Go
 func TestFoo(t *testing.T)
+```
+
+### <a id="foo" href="#foo">func foo() bool</a>
+
+```
+searchKey: tests.foo
+tags: [function private]
+```
+
+```Go
+func foo() bool
 ```
 


### PR DESCRIPTION
Prior to this change, functions, constants, variables, etc. were in a random order. After this, they are sorted in exported-first, alphabetical ordering.

Fixes https://github.com/sourcegraph/sourcegraph/issues/22306

