### PR TITLE
API docs: do not incorrectly tag methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ All notable changes to `lsif-go` are documented in this file.
 
 Nothing yet.
 
+## v1.6.1
+
+## Fixed
+
+- API docs no longer incorrectly tags some methods as functions and vice-versa.
+
 ## v1.6.0
 
 ### Added

--- a/internal/indexer/documentation.go
+++ b/internal/indexer/documentation.go
@@ -822,10 +822,10 @@ func (d *docsIndexer) indexFuncDecl(fset *token.FileSet, p *packages.Package, in
 			}
 		}
 	}
-	if len(in.Type.Params.List) == 0 {
-		result.tags = append(result.tags, protocol.TagFunction)
-	} else {
+	if result.recvType != nil {
 		result.tags = append(result.tags, protocol.TagMethod)
+	} else {
+		result.tags = append(result.tags, protocol.TagFunction)
 	}
 	if private {
 		result.tags = append(result.tags, protocol.TagPrivate)

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
@@ -780,7 +780,7 @@
                       "newPage": false,
                       "searchKey": "testdata.Struct.ImplementsInterface",
                       "tags": [
-                        "function"
+                        "method"
                       ]
                     },
                     "label": {
@@ -824,7 +824,7 @@
                       "newPage": false,
                       "searchKey": "testdata.Struct.StructMethod",
                       "tags": [
-                        "function"
+                        "method"
                       ]
                     },
                     "label": {
@@ -1050,7 +1050,7 @@
                 "newPage": false,
                 "searchKey": "testdata.Parallel",
                 "tags": [
-                  "method"
+                  "function"
                 ]
               },
               "label": {
@@ -1072,7 +1072,7 @@
                 "newPage": false,
                 "searchKey": "testdata.Switch",
                 "tags": [
-                  "method"
+                  "function"
                 ]
               },
               "label": {

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
@@ -489,7 +489,7 @@ type Struct struct {
 
 ```
 searchKey: testdata.Struct.ImplementsInterface
-tags: [function]
+tags: [method]
 ```
 
 ```Go
@@ -516,7 +516,7 @@ func (s *Struct) MachineLearning(
 
 ```
 searchKey: testdata.Struct.StructMethod
-tags: [function]
+tags: [method]
 ```
 
 ```Go
@@ -667,7 +667,7 @@ tags: [package private]
 
 ```
 searchKey: testdata.Parallel
-tags: [method]
+tags: [function]
 ```
 
 ```Go
@@ -680,7 +680,7 @@ Parallel invokes each of the given parallelizable functions in their own gorouti
 
 ```
 searchKey: testdata.Switch
-tags: [method]
+tags: [function]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.json
@@ -47,7 +47,7 @@
                 "newPage": false,
                 "searchKey": "tests.BenchmarkFoo",
                 "tags": [
-                  "method",
+                  "function",
                   "private",
                   "benchmark"
                 ]
@@ -71,7 +71,7 @@
                 "newPage": false,
                 "searchKey": "tests.TestFoo",
                 "tags": [
-                  "method",
+                  "function",
                   "private",
                   "test"
                 ]

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests.md
@@ -20,7 +20,7 @@ tags: [package private]
 
 ```
 searchKey: tests.BenchmarkFoo
-tags: [method private benchmark]
+tags: [function private benchmark]
 ```
 
 ```Go
@@ -31,7 +31,7 @@ func BenchmarkFoo(b *testing.B)
 
 ```
 searchKey: tests.TestFoo
-tags: [method private test]
+tags: [function private test]
 ```
 
 ```Go

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.json
@@ -47,7 +47,7 @@
                 "newPage": false,
                 "searchKey": "pkg_test.TestFoo",
                 "tags": [
-                  "method",
+                  "function",
                   "private",
                   "test"
                 ]

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/internal/shouldvisit/tests_separate_test.md
@@ -16,7 +16,7 @@ tags: [package private]
 
 ```
 searchKey: pkg_test.TestFoo
-tags: [method private test]
+tags: [function private test]
 ```
 
 ```Go


### PR DESCRIPTION
This conditional was quite wrong, and would tag any function with parameters as a method - obviously wrong and a typo.

This fixes it, and confirms via test data that it is indeed correct now.