### PR TITLE
API docs: do not panic on missing type information from obscure main-exported types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,22 +11,26 @@ All notable changes to `lsif-go` are documented in this file.
 
 ## Unreleased changes
 
+### Fixed
+
+- An issue where indexing would fail if `package main` contained exported data types. [#185](https://github.com/sourcegraph/lsif-go/pull/185)
+
 ## v1.6.3
 
-## Changed
+### Changed
 
 - Improved error messages.
 
 ## v1.6.2
 
-## Fixed
+### Fixed
 
 - API docs no longer incorrectly tags Functions/Variables/etc sections as a package.
 - API docs no longer emits null tag lists in violation of the spec.
 
 ## v1.6.1
 
-## Fixed
+### Fixed
 
 - API docs no longer incorrectly tags some methods as functions and vice-versa.
 

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
@@ -1084,6 +1084,29 @@
           },
           {
             "node": {
+              "pathID": "/#main",
+              "documentation": {
+                "identifier": "main",
+                "newPage": false,
+                "searchKey": "testdata.main",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func main()"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc main()\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
               "pathID": "/#useOfCompositeStructs",
               "documentation": {
                 "identifier": "useOfCompositeStructs",

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
@@ -56,6 +56,7 @@ testdata is a small package containing sample Go source code used for testing th
 * [Functions](#func)
     * [func Parallel(ctx context.Context, fns ...ParallelizableFunc) error](#Parallel)
     * [func Switch(interfaceValue interface{}) bool](#Switch)
+    * [func main()](#main)
     * [func useOfCompositeStructs()](#useOfCompositeStructs)
 
 
@@ -685,6 +686,17 @@ tags: [function]
 
 ```Go
 func Switch(interfaceValue interface{}) bool
+```
+
+### <a id="main" href="#main">func main()</a>
+
+```
+searchKey: testdata.main
+tags: [function private]
+```
+
+```Go
+func main()
 ```
 
 ### <a id="useOfCompositeStructs" href="#useOfCompositeStructs">func useOfCompositeStructs()</a>

--- a/internal/testdata/minimal_main.go
+++ b/internal/testdata/minimal_main.go
@@ -1,0 +1,9 @@
+package main
+
+type User struct {
+	Id, Name string
+}
+
+type UserResource struct{}
+
+func main() {}


### PR DESCRIPTION
Prior to this change, we would panic (nil pointer deref) in the event that we
encounter an exported type inside of a `package main` (which is non-sensical and
a linter error in Go):

```
package main

type Foo struct{}

func main() {}
```

This may be a bug in `go/packages`, since we are able to pick up type information for
the `main` symbol itself (ironic!) - but I'm not sure. For now, at least don't panic
/ fail to index everything else.

Signed-off-by: Stephen Gutekanst <stephen@sourcegraph.com>