### PR TITLE
Switch to alpine as base image for lsif-go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-FROM sourcegraph/src-cli:3.29.1@sha256:bfdec9e91fdd9d9bac4eab89c9496a9e8e027ffcac0048d56893d3747f8b7da9 AS src-cli
+FROM sourcegraph/src-cli:3.30.4@sha256:76ee253f9ba6ed1a8fdc46ab1e3f333ea0813841d34feb1aa9b8b57edce4eaab AS src-cli
 
-FROM golang:1.16-buster@sha256:71f35a85bbd89645bc9f95abe4da751958677d66094bebfa5d9a7fcaadc8fa27
+FROM golang:1.16.7-alpine@sha256:3e6a2def9a57f23344a75bd71d9cd79726f0fbaf4b75330be5669773df0e9d4c
+
+RUN apk add --no-cache git=2.32.0-r0
 
 COPY --from=src-cli /usr/bin/src /usr/bin/
 COPY lsif-go /usr/bin/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM sourcegraph/src-cli:3.30.4@sha256:76ee253f9ba6ed1a8fdc46ab1e3f333ea0813841d34feb1aa9b8b57edce4eaab AS src-cli
+FROM sourcegraph/src-cli:3.33.0@sha256:0a156eee108a1605a53de046dc6caaa2a711bba786ac27735dc111e8eb1af289 AS src-cli
 
-FROM golang:1.16.7-alpine@sha256:3e6a2def9a57f23344a75bd71d9cd79726f0fbaf4b75330be5669773df0e9d4c
+FROM golang:1.17.1-alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
 
-RUN apk add --no-cache git=2.32.0-r0
+RUN apk add --no-cache git=2.32.0-r0 build-base=0.5-r2
 
 COPY --from=src-cli /usr/bin/src /usr/bin/
 COPY lsif-go /usr/bin/


### PR DESCRIPTION
This reduces the image size from 841MB to 346MB, should give a significant boost in startup time.
Q: Do we rely on any tools other than git to be installed?