### PR TITLE
API docs: add tests & fix issue indexing illegal moby/moby Go code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ All notable changes to `lsif-go` are documented in this file.
 
 ## Unreleased changes
 
+## v1.6.6
+
+### Fixed
+
+- An issue where illegal code (conflicting test/non-test symbol names, such as in some moby/moby packages) would fail to index. [#186](https://github.com/sourcegraph/lsif-go/pull/186)
+
 ## v1.6.5
 
 ### Fixed

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -455,8 +455,11 @@ func TestIndexer_shouldVisitPackage(t *testing.T) {
 		}
 	}
 	autogold.Want("visited", map[string]bool{
-		"github.com/sourcegraph/lsif-go/internal/testdata":                   true,
-		"github.com/sourcegraph/lsif-go/internal/testdata/duplicate_path_id": true,
+		"github.com/sourcegraph/lsif-go/internal/testdata":                          true,
+		"github.com/sourcegraph/lsif-go/internal/testdata/conflicting_test_symbols": false,
+		"github.com/sourcegraph/lsif-go/internal/testdata/conflicting_test_symbols [github.com/sourcegraph/lsif-go/internal/testdata/conflicting_test_symbols.test]": true,
+		"github.com/sourcegraph/lsif-go/internal/testdata/conflicting_test_symbols.test":                                                                             false,
+		"github.com/sourcegraph/lsif-go/internal/testdata/duplicate_path_id":                                                                                         true,
 		"…/secret":              true,
 		"…/shouldvisit/notests": true,
 		"…/shouldvisit/tests":   false,

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/conflicting_test_symbols.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/conflicting_test_symbols.json
@@ -1,0 +1,181 @@
+{
+  "pathID": "/conflicting_test_symbols",
+  "documentation": {
+    "identifier": "conflicting_test_symbols",
+    "newPage": true,
+    "searchKey": "conflicting_test_symbols",
+    "tags": [
+      "private",
+      "package"
+    ]
+  },
+  "label": {
+    "kind": "plaintext",
+    "value": "Package osl"
+  },
+  "detail": {
+    "kind": "markdown",
+    "value": ""
+  },
+  "children": [
+    {
+      "node": {
+        "pathID": "/conflicting_test_symbols#var",
+        "documentation": {
+          "identifier": "var",
+          "newPage": false,
+          "searchKey": "",
+          "tags": [
+            "private"
+          ]
+        },
+        "label": {
+          "kind": "plaintext",
+          "value": "Variables"
+        },
+        "detail": {
+          "kind": "plaintext",
+          "value": ""
+        },
+        "children": [
+          {
+            "node": {
+              "pathID": "/conflicting_test_symbols#ErrNotImplemented",
+              "documentation": {
+                "identifier": "ErrNotImplemented",
+                "newPage": false,
+                "searchKey": "osl.ErrNotImplemented",
+                "tags": [
+                  "variable",
+                  "interface"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "var ErrNotImplemented"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nvar ErrNotImplemented = errors.New(\"not implemented\")\n```\n\nErrNotImplemented is for platforms which don't implement sandbox \n\n"
+              },
+              "children": null
+            }
+          }
+        ]
+      }
+    },
+    {
+      "node": {
+        "pathID": "/conflicting_test_symbols#func",
+        "documentation": {
+          "identifier": "func",
+          "newPage": false,
+          "searchKey": "",
+          "tags": [
+            "private"
+          ]
+        },
+        "label": {
+          "kind": "plaintext",
+          "value": "Functions"
+        },
+        "detail": {
+          "kind": "plaintext",
+          "value": ""
+        },
+        "children": [
+          {
+            "node": {
+              "pathID": "/conflicting_test_symbols#GenerateKey",
+              "documentation": {
+                "identifier": "GenerateKey",
+                "newPage": false,
+                "searchKey": "osl.GenerateKey",
+                "tags": [
+                  "function"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func GenerateKey(containerID string) string"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc GenerateKey(containerID string) string\n```\n\nGenerateKey generates a sandbox key based on the passed container id. \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/conflicting_test_symbols#NewSandbox",
+              "documentation": {
+                "identifier": "NewSandbox",
+                "newPage": false,
+                "searchKey": "osl.NewSandbox",
+                "tags": [
+                  "function"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error)"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error)\n```\n\nNewSandbox provides a new sandbox instance created in an os specific way provided a key which uniquely identifies the sandbox \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/conflicting_test_symbols#newKey",
+              "documentation": {
+                "identifier": "newKey",
+                "newPage": false,
+                "searchKey": "osl.newKey",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func newKey(t *testing.T) (string, error)"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc newKey(t *testing.T) (string, error)\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/conflicting_test_symbols#verifySandbox",
+              "documentation": {
+                "identifier": "verifySandbox",
+                "newPage": false,
+                "searchKey": "osl.verifySandbox",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func verifySandbox(t *testing.T, s Sandbox)"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc verifySandbox(t *testing.T, s Sandbox)\n```\n\n"
+              },
+              "children": null
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/conflicting_test_symbols.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/conflicting_test_symbols.md
@@ -1,0 +1,86 @@
+# Package osl
+
+## Index
+
+* [Variables](#var)
+    * [var ErrNotImplemented](#ErrNotImplemented)
+* [Functions](#func)
+    * [func GenerateKey(containerID string) string](#GenerateKey)
+    * [func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error)](#NewSandbox)
+    * [func newKey(t *testing.T) (string, error)](#newKey)
+    * [func verifySandbox(t *testing.T, s Sandbox)](#verifySandbox)
+
+
+## <a id="var" href="#var">Variables</a>
+
+```
+tags: [private]
+```
+
+### <a id="ErrNotImplemented" href="#ErrNotImplemented">var ErrNotImplemented</a>
+
+```
+searchKey: osl.ErrNotImplemented
+tags: [variable interface]
+```
+
+```Go
+var ErrNotImplemented = errors.New("not implemented")
+```
+
+ErrNotImplemented is for platforms which don't implement sandbox 
+
+## <a id="func" href="#func">Functions</a>
+
+```
+tags: [private]
+```
+
+### <a id="GenerateKey" href="#GenerateKey">func GenerateKey(containerID string) string</a>
+
+```
+searchKey: osl.GenerateKey
+tags: [function]
+```
+
+```Go
+func GenerateKey(containerID string) string
+```
+
+GenerateKey generates a sandbox key based on the passed container id. 
+
+### <a id="NewSandbox" href="#NewSandbox">func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error)</a>
+
+```
+searchKey: osl.NewSandbox
+tags: [function]
+```
+
+```Go
+func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error)
+```
+
+NewSandbox provides a new sandbox instance created in an os specific way provided a key which uniquely identifies the sandbox 
+
+### <a id="newKey" href="#newKey">func newKey(t *testing.T) (string, error)</a>
+
+```
+searchKey: osl.newKey
+tags: [function private]
+```
+
+```Go
+func newKey(t *testing.T) (string, error)
+```
+
+### <a id="verifySandbox" href="#verifySandbox">func verifySandbox(t *testing.T, s Sandbox)</a>
+
+```
+searchKey: osl.verifySandbox
+tags: [function private]
+```
+
+```Go
+func verifySandbox(t *testing.T, s Sandbox)
+```
+

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
@@ -1132,6 +1132,9 @@
       }
     },
     {
+      "pathID": "/conflicting_test_symbols"
+    },
+    {
       "pathID": "/duplicate_path_id"
     }
   ]

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
@@ -8,6 +8,7 @@ testdata is a small package containing sample Go source code used for testing th
 
 * Subpages
   * [internal](internal.md)
+  * [conflicting_test_symbols](conflicting_test_symbols.md)
   * [duplicate_path_id](duplicate_path_id.md)
 * [Constants](#const)
     * [const AliasedString](#AliasedString)

--- a/internal/testdata/conflicting_test_symbols/sandbox_unsupported.go
+++ b/internal/testdata/conflicting_test_symbols/sandbox_unsupported.go
@@ -1,6 +1,5 @@
 // From https://github.com/moby/moby/blob/master/libnetwork/osl/sandbox_unsupported.go
-
-// +build !linux,!windows,!freebsd
+// Build tag constraints removed here to ensure this code is tested on CI.
 
 package osl
 

--- a/internal/testdata/conflicting_test_symbols/sandbox_unsupported.go
+++ b/internal/testdata/conflicting_test_symbols/sandbox_unsupported.go
@@ -1,0 +1,24 @@
+// From https://github.com/moby/moby/blob/master/libnetwork/osl/sandbox_unsupported.go
+
+// +build !linux,!windows,!freebsd
+
+package osl
+
+import "errors"
+
+var (
+	// ErrNotImplemented is for platforms which don't implement sandbox
+	ErrNotImplemented = errors.New("not implemented")
+)
+
+// NewSandbox provides a new sandbox instance created in an os specific way
+// provided a key which uniquely identifies the sandbox
+func NewSandbox(key string, osCreate, isRestore bool) (Sandbox, error) {
+	return nil, ErrNotImplemented
+}
+
+// GenerateKey generates a sandbox key based on the passed
+// container id.
+func GenerateKey(containerID string) string {
+	return ""
+}

--- a/internal/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
+++ b/internal/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
@@ -1,0 +1,20 @@
+// From https://github.com/moby/moby/blob/master/libnetwork/osl/sandbox_unsupported_test.go
+
+// +build !linux
+
+package osl
+
+import (
+	"errors"
+	"testing"
+)
+
+var ErrNotImplemented = errors.New("not implemented")
+
+func newKey(t *testing.T) (string, error) {
+	return "", ErrNotImplemented
+}
+
+func verifySandbox(t *testing.T, s Sandbox) {
+	return
+}

--- a/internal/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
+++ b/internal/testdata/conflicting_test_symbols/sandbox_unsupported_test.go
@@ -1,6 +1,5 @@
 // From https://github.com/moby/moby/blob/master/libnetwork/osl/sandbox_unsupported_test.go
-
-// +build !linux
+// Build tag constraints removed here to ensure this code is tested on CI.
 
 package osl
 


### PR DESCRIPTION
https://github.com/moby/moby contains some illegal Go code (conflicting symbols defined in `_test.go` and non-`_test.go`) which confuses `go/packages` and results in some definition data not being present.

This adds test for this edge case, and makes it so we merely do not index such illegally-conflicting symbols for API docs.

Note: It is possible we will also run into this with other types of illegally conflicting symbols: this PR only handles `var` / `const` conflicts, we could run into this with type specs and function declarations theoretically. I have not handled those in this PR, is it reasonable to hope that's not in the wild, too?