### PR TITLE
API docs: fix issue with missing API docs on repositories containing Go files with multiple init funcs in them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to `lsif-go` are documented in this file.
 
 ## Unreleased changes
 
+### Fixed
+
+- An issue where API docs would not be generated for packages containing multiple `init` functions in the same file. [#195](https://github.com/sourcegraph/lsif-go/pull/195)
+
 ## v1.6.6
 
 ### Fixed

--- a/internal/indexer/documentation.go
+++ b/internal/indexer/documentation.go
@@ -819,7 +819,7 @@ func (d *docsIndexer) indexFuncDecl(fset *token.FileSet, p *packages.Package, in
 		if *initIndex == 1 {
 			result.name = fmt.Sprintf("%s.%s", result.name, fileName)
 		} else {
-			result.name = fmt.Sprintf("%s.%s.%v", result.name, fileName, initIndex)
+			result.name = fmt.Sprintf("%s.%s.%v", result.name, fileName, *initIndex)
 		}
 		*initIndex++
 	}

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.json
@@ -156,6 +156,52 @@
           },
           {
             "node": {
+              "pathID": "/duplicate_path_id#init.main.go.2",
+              "documentation": {
+                "identifier": "init.main.go.2",
+                "newPage": false,
+                "searchKey": "gosrc.init",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func init()"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc init()\n```\n\ntwo inits in the same file is legal \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/duplicate_path_id#init.main.go.3",
+              "documentation": {
+                "identifier": "init.main.go.3",
+                "newPage": false,
+                "searchKey": "gosrc.init",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func init()"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc init()\n```\n\nthree inits in the same file is legal \n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
               "pathID": "/duplicate_path_id#init.two.go",
               "documentation": {
                 "identifier": "init.two.go",

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/duplicate_path_id.md
@@ -8,6 +8,8 @@
     * [type sourceMeta struct{}](#sourceMeta)
 * [Functions](#func)
     * [func init()](#init.main.go)
+    * [func init()](#init.main.go.2)
+    * [func init()](#init.main.go.3)
     * [func init()](#init.two.go)
 
 
@@ -66,6 +68,32 @@ tags: [function private]
 ```Go
 func init()
 ```
+
+### <a id="init.main.go.2" href="#init.main.go.2">func init()</a>
+
+```
+searchKey: gosrc.init
+tags: [function private]
+```
+
+```Go
+func init()
+```
+
+two inits in the same file is legal 
+
+### <a id="init.main.go.3" href="#init.main.go.3">func init()</a>
+
+```
+searchKey: gosrc.init
+tags: [function private]
+```
+
+```Go
+func init()
+```
+
+three inits in the same file is legal 
 
 ### <a id="init.two.go" href="#init.two.go">func init()</a>
 

--- a/internal/testdata/duplicate_path_id/main.go
+++ b/internal/testdata/duplicate_path_id/main.go
@@ -10,3 +10,11 @@ func fetchMeta() (string, *importMeta, *sourceMeta) {
 
 func init() {
 }
+
+// two inits in the same file is legal
+func init() {
+}
+
+// three inits in the same file is legal
+func init() {
+}


### PR DESCRIPTION
Today, some repositories on Sourcegraph.com do not have any API docs OR have partial API docs, a symptom of duplicate path IDs being encountered when indexing API docs (which should theoretically be impossible.)

One such issue is that for multiple `init` functions in a single Go file, today we emit path IDs like:

```
init.main.go.0xc0043fba90
init.main.go.0xc0043fba90
init.main.go.0xc0043fba90
```

This is because the _number_ (which init function it is) was incorrectly formatted as a pointer instead of an integer:

```
init.main.go.1
init.main.go.2
init.main.go.3
```

This fixes that issue and adds tests for it.

Helps sourcegraph/sourcegraph#24255