### PR TITLE
API docs: add support for indexing code with illegal multiple main functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to `lsif-go` are documented in this file.
 ### Fixed
 
 - An issue where API docs would not be generated for packages containing multiple `init` functions in the same file. [#195](https://github.com/sourcegraph/lsif-go/pull/195)
+- An issue where API docs would not be generated for packages contianing multiple (illegal) `main` functions in the same file ([example](https://raw.githubusercontent.com/golang/go/master/test/mainsig.go)). [#196](https://github.com/sourcegraph/lsif-go/pull/196)
 
 ## v1.6.6
 

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -460,6 +460,7 @@ func TestIndexer_shouldVisitPackage(t *testing.T) {
 		"github.com/sourcegraph/lsif-go/internal/testdata/conflicting_test_symbols [github.com/sourcegraph/lsif-go/internal/testdata/conflicting_test_symbols.test]": true,
 		"github.com/sourcegraph/lsif-go/internal/testdata/conflicting_test_symbols.test":                                                                             false,
 		"github.com/sourcegraph/lsif-go/internal/testdata/duplicate_path_id":                                                                                         true,
+		"github.com/sourcegraph/lsif-go/internal/testdata/illegal_multiple_mains":                                                                                    true,
 		"…/secret":              true,
 		"…/shouldvisit/notests": true,
 		"…/shouldvisit/tests":   false,

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/illegal_multiple_mains.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/illegal_multiple_mains.json
@@ -1,0 +1,137 @@
+{
+  "pathID": "/illegal_multiple_mains",
+  "documentation": {
+    "identifier": "illegal_multiple_mains",
+    "newPage": true,
+    "searchKey": "illegal_multiple_mains",
+    "tags": [
+      "private",
+      "package"
+    ]
+  },
+  "label": {
+    "kind": "plaintext",
+    "value": "Package main"
+  },
+  "detail": {
+    "kind": "markdown",
+    "value": ""
+  },
+  "children": [
+    {
+      "node": {
+        "pathID": "/illegal_multiple_mains#func",
+        "documentation": {
+          "identifier": "func",
+          "newPage": false,
+          "searchKey": "",
+          "tags": [
+            "private"
+          ]
+        },
+        "label": {
+          "kind": "plaintext",
+          "value": "Functions"
+        },
+        "detail": {
+          "kind": "plaintext",
+          "value": ""
+        },
+        "children": [
+          {
+            "node": {
+              "pathID": "/illegal_multiple_mains#init.main.go",
+              "documentation": {
+                "identifier": "init.main.go",
+                "newPage": false,
+                "searchKey": "main.init",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func init(int)"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc init(int)\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/illegal_multiple_mains#init.main.go.2",
+              "documentation": {
+                "identifier": "init.main.go.2",
+                "newPage": false,
+                "searchKey": "main.init",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func init() int"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc init() int\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/illegal_multiple_mains#main",
+              "documentation": {
+                "identifier": "main",
+                "newPage": false,
+                "searchKey": "main.main",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func main(int)"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc main(int)\n```\n\n"
+              },
+              "children": null
+            }
+          },
+          {
+            "node": {
+              "pathID": "/illegal_multiple_mains#main.main.go.2",
+              "documentation": {
+                "identifier": "main.main.go.2",
+                "newPage": false,
+                "searchKey": "main.main",
+                "tags": [
+                  "function",
+                  "private"
+                ]
+              },
+              "label": {
+                "kind": "plaintext",
+                "value": "func main() int"
+              },
+              "detail": {
+                "kind": "markdown",
+                "value": "```Go\nfunc main() int\n```\n\n"
+              },
+              "children": null
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/illegal_multiple_mains.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/illegal_multiple_mains.md
@@ -1,0 +1,61 @@
+# Package main
+
+## Index
+
+* [Functions](#func)
+    * [func init(int)](#init.main.go)
+    * [func init() int](#init.main.go.2)
+    * [func main(int)](#main)
+    * [func main() int](#main.main.go.2)
+
+
+## <a id="func" href="#func">Functions</a>
+
+```
+tags: [private]
+```
+
+### <a id="init.main.go" href="#init.main.go">func init(int)</a>
+
+```
+searchKey: main.init
+tags: [function private]
+```
+
+```Go
+func init(int)
+```
+
+### <a id="init.main.go.2" href="#init.main.go.2">func init() int</a>
+
+```
+searchKey: main.init
+tags: [function private]
+```
+
+```Go
+func init() int
+```
+
+### <a id="main" href="#main">func main(int)</a>
+
+```
+searchKey: main.main
+tags: [function private]
+```
+
+```Go
+func main(int)
+```
+
+### <a id="main.main.go.2" href="#main.main.go.2">func main() int</a>
+
+```
+searchKey: main.main
+tags: [function private]
+```
+
+```Go
+func main() int
+```
+

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.json
@@ -1136,6 +1136,9 @@
     },
     {
       "pathID": "/duplicate_path_id"
+    },
+    {
+      "pathID": "/illegal_multiple_mains"
     }
   ]
 }

--- a/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
+++ b/internal/indexer/testdata/TestIndexer_documentation/testdata/index.md
@@ -10,6 +10,7 @@ testdata is a small package containing sample Go source code used for testing th
   * [internal](internal.md)
   * [conflicting_test_symbols](conflicting_test_symbols.md)
   * [duplicate_path_id](duplicate_path_id.md)
+  * [illegal_multiple_mains](illegal_multiple_mains.md)
 * [Constants](#const)
     * [const AliasedString](#AliasedString)
     * [const Const](#Const)

--- a/internal/testdata/illegal_multiple_mains/main.go
+++ b/internal/testdata/illegal_multiple_mains/main.go
@@ -1,0 +1,15 @@
+// File copied from: https://github.com/golang/go/blob/master/test/mainsig.go
+
+// errorcheck
+
+// Copyright 2020 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package main
+
+func main(int)  {}           // ERROR "func main must have no arguments and no return values"
+func main() int { return 1 } // ERROR "func main must have no arguments and no return values" "main redeclared in this block"
+
+func init(int)  {}           // ERROR "func init must have no arguments and no return values"
+func init() int { return 1 } // ERROR "func init must have no arguments and no return values"


### PR DESCRIPTION
Repositories like Go (hopefully just Go, but there are signals there may be more)
have multiple `main` functions in the same Go file, which is illegal and rejected
by the Go compiler. Additionally, it produces illegal API docs due to duplicate
path IDs:

```
t=2021-08-31T17:02:59-0700 lvl=eror msg="API docs: upload failed due to duplicate pathIDs" duplicates=1 nonDuplicates=71
t=2021-08-31T17:02:59-0700 lvl=warn msg="API docs: duplicate pathID forbidden" pathID=/illegal_multiple_mains#main
```

This adds a test case for it, and also adds support for it so the duplicative one becomes e.g. `/illegal_multiple_mains#main.<file>.<number>` similar to multiple init functions.

Helps sourcegraph/sourcegraph#24255