### PR TITLE
correct sha for golang image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM sourcegraph/src-cli:3.29.1@sha256:bfdec9e91fdd9d9bac4eab89c9496a9e8e027ffcac0048d56893d3747f8b7da9 AS src-cli
 
-FROM golang:1.16-buster@sha256:71f35a85bbd89645bc9f95abe4da751958677d66094bebfa5d9a7fcaadc8fa27
+FROM golang:1.16-buster@sha256:d93712777042a4abf73182a29649e78368b1639b6bd5df61733708916e40d517
 
 COPY --from=src-cli /usr/bin/src /usr/bin/
 COPY lsif-go /usr/bin/


### PR DESCRIPTION
This is meant to solve an issue in the golang version surfaced in this [issue](https://github.com/sourcegraph/lsif-go/issues/204#issuecomment-947662106), it looks like the image sha in this [PR](https://github.com/sourcegraph/lsif-go/commit/ab96b0194a84261e97a5f8f175e0973c51b3454b) wasn't updated despite the tag being updated. This results in pulling an older go version

```Bash
warrengifford@Warrens-MacBook-Pro ~ % docker run -it --entrypoint=/bin/sh golang:1.16-buster@sha256:71f35a85bbd89645bc9f95abe4da751958677d66094bebfa5d9a7fcaadc8fa27
# go version
go version go1.14.5 linux/amd64
# exit
warrengifford@Warrens-MacBook-Pro ~ % docker run -it --entrypoint=/bin/sh golang:1.16-buster
Unable to find image 'golang:1.16-buster' locally
1.16-buster: Pulling from library/golang
07471e81507f: Pull complete
c6cef1aa2170: Pull complete
13a51f13be8e: Pull complete
def39d67a1a7: Pull complete
e04882e62cc4: Pull complete
9c9da2c3ca17: Pull complete
6a58c678a585: Pull complete
Digest: sha256:d93712777042a4abf73182a29649e78368b1639b6bd5df61733708916e40d517
Status: Downloaded newer image for golang:1.16-buster
# go version
go version go1.16.9 linux/amd64
```

I just used the sha associated with the tag `golang:1.16-buster` 🙏 