### PR TITLE
Add --skip-deps flag to reduce memory usage

### DIFF
--- a/cmd/lsif-go/args.go
+++ b/cmd/lsif-go/args.go
@@ -26,6 +26,7 @@ var (
 	verbosity        int
 	noOutput         bool
 	noAnimation      bool
+	skipDeps         bool
 )
 
 func init() {
@@ -43,6 +44,9 @@ func init() {
 	// Repository remote and tag options (inferred by git)
 	app.Flag("repository-remote", "Specifies the canonical name of the repository remote.").Default(defaultRepositoryRemote.Value()).StringVar(&repositoryRemote)
 	app.Flag("module-version", "Specifies the version of the module defined by module-root.").Default(defaultModuleVersion.Value()).StringVar(&moduleVersion)
+
+	// Feature options
+	app.Flag("skip-deps", "Do not load depedencies - reduces memory usage but omits interface implementation data from deps.").Default("false").BoolVar(&skipDeps)
 
 	// Verbosity options
 	app.Flag("quiet", "Do not output to stdout or stderr.").Short('q').Default("false").BoolVar(&noOutput)

--- a/cmd/lsif-go/args.go
+++ b/cmd/lsif-go/args.go
@@ -46,7 +46,7 @@ func init() {
 	app.Flag("module-version", "Specifies the version of the module defined by module-root.").Default(defaultModuleVersion.Value()).StringVar(&moduleVersion)
 
 	// Feature options
-	app.Flag("skip-deps", "Do not load depedencies - reduces memory usage but omits interface implementation data from deps.").Default("false").BoolVar(&skipDeps)
+	app.Flag("skip-deps", "Do not load depedencies - reduces memory usage but omits interface implementation data from deps.").Default("true").BoolVar(&skipDeps)
 
 	// Verbosity options
 	app.Flag("quiet", "Do not output to stdout or stderr.").Short('q').Default("false").BoolVar(&noOutput)

--- a/cmd/lsif-go/index.go
+++ b/cmd/lsif-go/index.go
@@ -12,7 +12,7 @@ import (
 	"github.com/sourcegraph/sourcegraph/lib/codeintel/lsif/protocol/writer"
 )
 
-func writeIndex(repositoryRoot, repositoryRemote, projectRoot, moduleName, moduleVersion string, dependencies map[string]gomod.GoModule, projectDependencies []string, outFile string, outputOptions output.Options) error {
+func writeIndex(repositoryRoot, repositoryRemote, projectRoot, moduleName, moduleVersion string, dependencies map[string]gomod.GoModule, projectDependencies []string, outFile string, outputOptions output.Options, skipDeps bool) error {
 	start := time.Now()
 
 	out, err := os.Create(outFile)
@@ -44,6 +44,7 @@ func writeIndex(repositoryRoot, repositoryRemote, projectRoot, moduleName, modul
 		writer.NewJSONWriter(out),
 		packageDataCache,
 		outputOptions,
+		skipDeps,
 	)
 
 	if err := indexer.Index(); err != nil {

--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -75,6 +75,7 @@ func mainErr() (err error) {
 		projectDependencies,
 		outFile,
 		outputOptions,
+		skipDeps,
 	); err != nil {
 		return fmt.Errorf("failed to index: %v", err)
 	}

--- a/internal/indexer/indexer_test.go
+++ b/internal/indexer/indexer_test.go
@@ -46,6 +46,7 @@ func TestIndexer(t *testing.T) {
 		w,
 		NewPackageDataCache(),
 		output.Options{},
+		false,
 	)
 
 	if err := indexer.Index(); err != nil {
@@ -650,6 +651,7 @@ func TestIndexer_documentation(t *testing.T) {
 				writer.NewJSONWriter(&buf),
 				NewPackageDataCache(),
 				output.Options{},
+				false,
 			)
 			if err := indexer.Index(); err != nil {
 				t.Fatalf("unexpected error indexing testdata: %s", err.Error())
@@ -689,6 +691,7 @@ func TestIndexer_shouldVisitPackage(t *testing.T) {
 		w,
 		NewPackageDataCache(),
 		output.Options{},
+		false,
 	)
 
 	if err := indexer.loadPackages(false); err != nil {


### PR DESCRIPTION
This allows us to continue using the latest version of lsif-go in sourcegraph/sourcegraph CI without running out of memory. The downside is that it omits interface implementation data from dependencies.

We might be able to load one dep at a time and extract implementation data from it, which would obviate this flag. That's a much bigger change, so I opted for a quick workaround.

See https://github.com/sourcegraph/sourcegraph/issues/27211