### PR TITLE
fix: Don't emit duplicate `next` edges

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -463,7 +463,6 @@ func (i *Indexer) emitImportMonikerNamedDefinition(p *packages.Package, pkg *pac
 
 	rangeID, _ := i.ensureRangeFor(position, obj)
 	resultSetID := i.emitter.EmitResultSet()
-	_ = i.emitter.EmitNext(rangeID, resultSetID)
 
 	i.indexDefinitionForRangeAndResult(p, document, obj, rangeID, resultSetID, false, ident)
 }


### PR DESCRIPTION
Before:

```
2) vertex 453 has multiple result sets
        on line #457: {457 edge next {453 454 [] 0}}
        on line #455: {455 edge next {453 454 [] 0}}
```

In between (I have updated lsif-validate to make a better message for this case):

```
2) duplicate edges deteced from 453 -> 454
        on line #455: {455 edge next {453 454 [] 0}}
        on line #457: {457 edge next {453 454 [] 0}}
```

After:

```
<sweet sweet nothingness>
```