### PR TITLE
Bump checkout action to v2.

### DIFF
--- a/.github/workflows/lsif.yml
+++ b/.github/workflows/lsif.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     container: sourcegraph/lsif-go
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v2
       - name: Generate LSIF data
         run: lsif-go
       - name: Upload LSIF data


### PR DESCRIPTION
Previously, we discovered a problem with the sg/sg
repo, only when using v2 of the checkout action.
However, this problem was not caught earlier because
lsif-go was using v1. We should keep the action versions
in sync across repos.