### PR TITLE
Fix missing 'name' argument in git remote command

### DIFF
--- a/internal/gomod/module_name.go
+++ b/internal/gomod/module_name.go
@@ -52,7 +52,7 @@ func resolveModuleName(repo, name string) (string, error) {
 	// Determine the canonical code host of the current repository
 	repoRepoRoot, err := vcs.RepoRootForImportPath(repo, false)
 	if err != nil {
-		help := "Make sure your git repo has a remote (git remote add git@github.com:owner/repo)"
+		help := "Make sure your git repo has a remote (git remote add origin git@github.com:owner/repo)"
 		return "", fmt.Errorf("%v\n\n%s", err, help)
 	}
 


### PR DESCRIPTION
It's not much, but hey, it's something.