### PR TITLE
Do not disable cgo (rm CGO_ENABLED=0)

### DIFF
--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -275,10 +275,6 @@ func (i *Indexer) loadPackage(deduplicate bool, patterns ...string) ([]*packages
 		// Only load tests for the current project.
 		// This greatly reduces memory usage when loading dependencies
 		Tests: isLoadingProject,
-
-		// CGO_ENABLED=0 makes sure that we can handle files with assembly
-		// and other problems that may occur (unsure of exact reasons at time of writing)
-		// Env: append(os.Environ(), "CGO_ENABLED=0"),
 	}
 
 	// Make sure we only load packages once per execution.

--- a/internal/indexer/indexer.go
+++ b/internal/indexer/indexer.go
@@ -9,7 +9,6 @@ import (
 	"go/types"
 	"log"
 	"math"
-	"os"
 	"path"
 	"strings"
 	"sync"
@@ -279,7 +278,7 @@ func (i *Indexer) loadPackage(deduplicate bool, patterns ...string) ([]*packages
 
 		// CGO_ENABLED=0 makes sure that we can handle files with assembly
 		// and other problems that may occur (unsure of exact reasons at time of writing)
-		Env: append(os.Environ(), "CGO_ENABLED=0"),
+		// Env: append(os.Environ(), "CGO_ENABLED=0"),
 	}
 
 	// Make sure we only load packages once per execution.


### PR DESCRIPTION
You can disable it with `env CGO_ENABLED=0 lsif-go` if necessary.

Fixes https://github.com/sourcegraph/sourcegraph/issues/33285

Might fix https://github.com/sourcegraph/sourcegraph/pull/30307#issuecomment-1041917665. I was unable to repro the error, but I was able to determine that `binding.go` is now included in the output whereas before this change it wasn't.

Might fix https://github.com/sourcegraph/lsif-go/issues/227 for the same reason.

I didn't notice any negative consequences of this change:

- gorillla/mux still works
- sourcegraph/src-cli still works
- sourcegraph/sourcegraph/lib still works without the [workaround](https://github.com/sourcegraph/sourcegraph/blob/672ea0c167b971fc01cc98ba55a11451401f77dd/lib/codeintel/repro_lang/src/workaround.go). Olaf had an [issue](https://github.com/sourcegraph/sourcegraph/pull/30307#issuecomment-1041917665) but I was unable to repro.
- google/gvisor (with C files) still doesn't work due to having `.c` files in Go packages without `import "C"`
- gonum/gonum (with assembly files) still works, same set of files ended up in the LSIF dump
- A fresh repo with https://riptutorial.com/go/example/21315/cgo--first-steps-tutorial emits more info than before this change