### PR TITLE
Add changelog entry for v1.7.6.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@
 
 All notable changes to `lsif-go` are documented in this file.
 
+## v1.7.6
+
+### Changed
+
+- The accompanying Docker image uses Go 1.17.7 and `src-cli` 3.37.0. (#235)
+
+### Fixed
+
+- Fixes a couple of panics (#230, #232).
+
 ## v1.7.5
 
 ### Features


### PR DESCRIPTION
@chrismwendt: is there a nice description for when the panics could happen that I could add to the changelog here? I couldn't quite figure out what user code would trigger the issues fixed in the patch.

### Test plan

Not needed since we're only adding a changelog entry.