### PR TITLE
Use the latest src-cli version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,5 @@
-FROM sourcegraph/src-cli:3.37.0@sha256:985bf866cfbd9cac6140169daf3f3b925ca5a8b4d82519b1bd847adeae574172 AS src-cli
-
 FROM golang:1.18.2@sha256:800d9b4fb6231053473df14d5a7116bfd33500bca5ca4c6d544de739d9a7d302
 
-COPY --from=src-cli /usr/bin/src /usr/bin/
+RUN curl -L https://sourcegraph.com/.api/src-cli/src_linux_amd64 -o /usr/bin/src && chmod +x /usr/bin/src
+
 COPY lsif-go /usr/bin/


### PR DESCRIPTION
Previously, we hardcoded the src-cli version to an older release. With
this change, we always pull the version of src-cli from the current
Sourcegraph website.

### Test plan

I built the docker image locally and verified with `src version`
```
❯ docker run -v $(pwd):/node -it sha256:52546a950dab13435ca2f24e16c53717df9c66e7f5a88a40a56c5e05fd07f7c8 /bin/bash
root@6298487f4b1d:/go# src version
Current version: 3.40.0
```
<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
