### PR TITLE
Disable animation by default

### DIFF
--- a/cmd/lsif-go/args.go
+++ b/cmd/lsif-go/args.go
@@ -25,7 +25,7 @@ var (
 	moduleVersion         string
 	verbosity             int
 	noOutput              bool
-	noAnimation           bool
+	animation             bool
 	depBatchSize          int
 	enableApiDocs         bool
 	enableImplementations bool
@@ -50,7 +50,7 @@ func init() {
 	// Verbosity options
 	app.Flag("quiet", "Do not output to stdout or stderr.").Short('q').Default("false").BoolVar(&noOutput)
 	app.Flag("verbose", "Output debug logs.").Short('v').CounterVar(&verbosity)
-	app.Flag("no-animation", "Do not animate output.").Default("true").BoolVar(&noAnimation)
+	app.Flag("animation", "Do not animate output.").Default("false").BoolVar(&animation)
 
 	app.Flag("dep-batch-size", "How many dependencies to load at once to limit memory usage (e.g. 100). 0 means load all at once.").Default("0").IntVar(&depBatchSize)
 

--- a/cmd/lsif-go/args.go
+++ b/cmd/lsif-go/args.go
@@ -50,7 +50,7 @@ func init() {
 	// Verbosity options
 	app.Flag("quiet", "Do not output to stdout or stderr.").Short('q').Default("false").BoolVar(&noOutput)
 	app.Flag("verbose", "Output debug logs.").Short('v').CounterVar(&verbosity)
-	app.Flag("no-animation", "Do not animate output.").Default("false").BoolVar(&noAnimation)
+	app.Flag("no-animation", "Do not animate output.").Default("true").BoolVar(&noAnimation)
 
 	app.Flag("dep-batch-size", "How many dependencies to load at once to limit memory usage (e.g. 100). 0 means load all at once.").Default("0").IntVar(&depBatchSize)
 

--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -48,7 +48,7 @@ func mainErr() (err error) {
 
 	outputOptions := output.Options{
 		Verbosity:      getVerbosity(),
-		ShowAnimations: !noAnimation,
+		ShowAnimations: animation,
 	}
 
 	moduleName, err := gomod.ModuleName(moduleRoot, repositoryRemote, outputOptions)


### PR DESCRIPTION
Animation currently breaks manual indexing of sourcegraph/sourcegraph
because it blocks a prompt from git about trusting a fingerprint.
Until we figure out a way to enable stdin together with animation, it's
best to disable animation so that customers don't experienc buggy
behavior out of the box.

### Test plan

I built the binary locally and manually verified that I was able to index sourcegraph/sourcegraph with the command `lsif-go` (no flags). Before this commit, I needed to manually add `--no-animation`, which is not obvious if you're a customer and trying to index a codebase.

<!--
  As part of SOC2/GN-104 and SOC2/GN-105 requirements, all pull requests are REQUIRED to
  provide a "test plan". A test plan is a loose explanation of what you have done or
  implemented to test this, as outlined in our Testing principles and guidelines:
  https://docs.sourcegraph.com/dev/background-information/testing_principles
  Write your test plan here after the "Test plan" header.
-->
