### PR TITLE
gomod: special case listing the stdlib

### DIFF
--- a/cmd/lsif-go/main.go
+++ b/cmd/lsif-go/main.go
@@ -51,7 +51,7 @@ func mainErr() (err error) {
 		ShowAnimations: animation,
 	}
 
-	moduleName, err := gomod.ModuleName(moduleRoot, repositoryRemote, outputOptions)
+	moduleName, isStdLib, err := gomod.ModuleName(moduleRoot, repositoryRemote, outputOptions)
 	if err != nil {
 		return fmt.Errorf("failed to infer module name: %v", err)
 	}
@@ -61,9 +61,12 @@ func mainErr() (err error) {
 		return fmt.Errorf("failed to list dependencies: %v", err)
 	}
 
-	projectDependencies, err := gomod.ListProjectDependencies(moduleRoot)
-	if err != nil {
-		return fmt.Errorf("failed to list project dependencies: %v", err)
+	var projectDependencies []string
+	if !isStdLib {
+		projectDependencies, err = gomod.ListProjectDependencies(moduleRoot)
+		if err != nil {
+			return fmt.Errorf("failed to list project dependencies: %v", err)
+		}
 	}
 
 	generationOptions := indexer.NewGenerationOptions()

--- a/internal/gomod/module_name_test.go
+++ b/internal/gomod/module_name_test.go
@@ -24,10 +24,16 @@ func TestResolveModuleName(t *testing.T) {
 			name:     "github.com/google/zoekt/some/sub/path",
 			expected: "https://github.com/sourcegraph/zoekt/some/sub/path",
 		},
+
+		{
+			repo:     "github.com/golang/go",
+			name:     "std",
+			expected: "https://github.com/golang/go",
+		},
 	}
 
 	for _, testCase := range testCases {
-		if actual, err := resolveModuleName(testCase.repo, testCase.name); err != nil {
+		if actual, _, err := resolveModuleName(testCase.repo, testCase.name); err != nil {
 			t.Fatalf("unexpected error: %s", err)
 		} else if actual != testCase.expected {
 			t.Errorf("unexpected module name. want=%q have=%q", testCase.expected, actual)


### PR DESCRIPTION
Before this commit lsif-go fails on the standard library for go. When running the "go list all" command fails to run with an error message like:

```
cannot find package "." in:
  path/to/a/vendor/dir
...
```

This might be an issue in upstream go list. However, you normally do need special handling of the go stdlib tool. In our case we can just skip listing dependencies since it is the standard library.

Test Plan: We eyeballed the lsif dump after running on stdlib, and it looked legitimate. However, we don't know much about lsif.

Co-authored-by: @stefanhengl 